### PR TITLE
Support ZLib compressed Flask Session signed cookies

### DIFF
--- a/badsecrets/modules/flask_signedcookies.py
+++ b/badsecrets/modules/flask_signedcookies.py
@@ -6,7 +6,7 @@ from badsecrets.base import BadsecretsBase
 
 
 class Flask_SignedCookies(BadsecretsBase):
-    identify_regex = re.compile(r"eyJ(?:[\w-]*\.)(?:[\w-]*\.)[\w-]*")
+    identify_regex = re.compile(r"\.?e[Jy](?:[\w-]*\.)(?:[\w-]*\.)[\w-]*")
     description = {"product": "Flask Signed Cookie", "secret": "Flask Password", "severity": "HIGH"}
 
     def check_secret(self, flask_cookie):


### PR DESCRIPTION
update regex pattern to support ZLib compressed cookies which are created if Flask Session cookie is large enough