### PR TITLE
improving express (cs) regex

### DIFF
--- a/badsecrets/modules/express_signedcookies_cs.py
+++ b/badsecrets/modules/express_signedcookies_cs.py
@@ -26,14 +26,14 @@ class ExpressSignedCookies_CS(BadsecretsBase):
     }
 
     def carve_regex(self):
-        return re.compile(r"(\w{1,64}=[^;]{4,512})[^\.]+\.sig=([^;]{27,86})")
+        return re.compile(r"(\w{1,64})=([^;]{4,512});.*?\1\.sig=([^;]{27,86});")
 
     def get_product_from_carve(self, regex_search):
-        return f"Data Cookie: [{regex_search.groups()[0]}] Signature Cookie: [{regex_search.groups()[1]}]"
+        return f"Data Cookie: [{regex_search.groups()[0]}={regex_search.groups()[1]}] Signature Cookie: [{regex_search.groups()[2]}]"
 
     def carve_to_check_secret(self, s):
-        if len(s.groups()) == 2:
-            r = self.check_secret(s.groups()[0], s.groups()[1])
+        if len(s.groups()) == 3:
+            r = self.check_secret(f"{s.groups()[0]}={s.groups()[1]}", s.groups()[2])
             return r
 
     def expressHMAC(self, payload, secret, hash_algorithm):

--- a/badsecrets/modules/express_signedcookies_cs.py
+++ b/badsecrets/modules/express_signedcookies_cs.py
@@ -26,7 +26,7 @@ class ExpressSignedCookies_CS(BadsecretsBase):
     }
 
     def carve_regex(self):
-        return re.compile(r"(\w{1,64})=([^;]{4,512});.*?\1\.sig=([^;]{27,86});")
+        return re.compile(r"(\w{1,64})=([^;]{4,512});.*?\1\.sig=([^;]{27,86})")
 
     def get_product_from_carve(self, regex_search):
         return f"Data Cookie: [{regex_search.groups()[0]}={regex_search.groups()[1]}] Signature Cookie: [{regex_search.groups()[2]}]"


### PR DESCRIPTION
The express_cs carve regex was catastrophically bad and caused hangs with long text.