### PR TITLE
Add Sails Express.js hardcoded secrets

### DIFF
--- a/badsecrets/resources/express_session_secrets.txt
+++ b/badsecrets/resources/express_session_secrets.txt
@@ -163,6 +163,7 @@ $uper$ecret$e$$ionKey
 8b2864a9c1da71b4ccefe6872e8b9594
 8b9f1a13d558c663ad474fe69cd3a004387c008b
 8d24f7b0d358a923
+9238cca11a83d473e10981c49c4f
 923903nsdklfwsu83838
 96826587412301
 97ba74d6ad6634e4e480d9619d1623dd
@@ -242,6 +243,7 @@ adfasdfa
 adfasdfsd*&$43$*(Ggfdgdfgsdfg)
 adgnjhu6342cdfgdf
 Adrian
+af9442683372850a85a87150c47b4a31
 Affidaluffendorpfi
 agent, 007
 agsf-asdf-2r2d-SÄP#%ER-adsf
@@ -699,6 +701,7 @@ express.io makes me very happy
 expressbasicsisareallyawesomeapp
 expressbasicsisareallycoolapp
 expressive-fothzxhcgl9wiks
+extremely-secure-keyboard-cat
 ezSQL and ezAuth
 F1F2F3F4F5F6
 f541b79594f6e0d176058bd4e17874e397e89145
@@ -1827,6 +1830,7 @@ somethingsomething
 Somethingsomething1234!test
 SOMETHINGSUPERSECRET
 SomethingYouKnow
+someVerySecureString
 Sommer
 sonotsecret
 Sonrascrocks!


### PR DESCRIPTION
See:
- https://github.com/balderdashy/sails/blob/master/lib/hooks/session/index.js
- https://github.com/balderdashy/sails/blob/master/test/unit/req.session.test.js
- https://github.com/balderdashy/sails/blob/master/docs/concepts/Sessions/sessions.md

For production, default secret should be a MD5 generated string from Date, random 64-byte and Node.js version (https://github.com/balderdashy/sails-generate), if not changed by the maintainer.