### PR TITLE
migrate from httpx to blasthttp

### DIFF
--- a/badsecrets/base.py
+++ b/badsecrets/base.py
@@ -5,7 +5,6 @@ import base64
 import hashlib
 import binascii
 import logging
-import httpx
 import yara
 import badsecrets.errors
 from abc import abstractmethod
@@ -90,25 +89,24 @@ class BadsecretsBase:
     def carve_regex(self):
         return None
 
-    def carve(self, body=None, cookies=None, headers=None, httpx_response=None, _yara_body_hit=None, **kwargs):
+    def carve(self, body=None, cookies=None, headers=None, http_response=None, _yara_body_hit=None, **kwargs):
         results = []
 
-        if not body and not cookies and not headers and httpx_response is None:
-            raise badsecrets.errors.CarveException("Either body/headers/cookies or httpx_response required")
+        if not body and not cookies and not headers and http_response is None:
+            raise badsecrets.errors.CarveException("Either body/headers/cookies or http_response required")
 
-        if httpx_response is not None:
+        if http_response is not None:
             if body or cookies or headers:
-                raise badsecrets.errors.CarveException("Body/cookies/headers and httpx_response cannot both be set")
+                raise badsecrets.errors.CarveException("Body/cookies/headers and http_response cannot both be set")
 
-            if isinstance(httpx_response, httpx.Response):
-                if not cookies:
-                    cookies = dict(httpx_response.cookies)
-                if not headers:
-                    headers = httpx_response.headers
-                if not body and hasattr(httpx_response, "text"):
-                    body = httpx_response.text
-            else:
-                raise badsecrets.errors.CarveException("httpx_response must be an httpx.Response object")
+            if not all(hasattr(http_response, a) for a in ("text", "headers", "cookies")):
+                raise badsecrets.errors.CarveException(
+                    "http_response must expose .text, .headers, and .cookies (e.g. blasthttp.Response)"
+                )
+
+            cookies = dict(http_response.cookies) or None
+            headers = http_response.headers
+            body = http_response.text
 
         if cookies and "cookies" in self.carve_locations:
             if not isinstance(cookies, dict):
@@ -396,9 +394,9 @@ def carve_all_modules(**kwargs):
 
     # Determine body text for YARA pre-scanning
     scan_body = kwargs.get("body")
-    httpx_resp = kwargs.get("httpx_response")
-    if not scan_body and httpx_resp is not None and isinstance(httpx_resp, httpx.Response):
-        scan_body = getattr(httpx_resp, "text", None)
+    http_resp = kwargs.get("http_response")
+    if not scan_body and http_resp is not None:
+        scan_body = getattr(http_resp, "text", None)
 
     # Run YARA pre-filter on body text (single pass, all rules)
     yara_body_matches = set()
@@ -419,33 +417,35 @@ def carve_all_modules(**kwargs):
         return results
 
 
-def build_prefilter_text(httpx_response=None, body=None):
+def build_prefilter_text(http_response=None, body=None):
     """Build text for YARA prefilter scanning, including headers + body.
 
     Active module prefilters may need to match on response headers (e.g. Set-Cookie)
     in addition to body content. This function constructs the combined text.
     """
     parts = []
-    if httpx_response is not None:
-        for name, value in httpx_response.headers.items():
+    if http_response is not None:
+        for name, value in http_response.headers.items():
             parts.append(f"{name}: {value}")
         parts.append("")
     text = body
-    if not text and httpx_response is not None:
-        text = getattr(httpx_response, "text", None)
+    if not text and http_response is not None:
+        text = getattr(http_response, "text", None)
     if text:
         parts.append(text)
     return "\n".join(parts) if parts else ""
 
 
-async def probe_all_modules(httpx_response=None, url=None, body=None, active_keys_map=None, **kwargs):
+async def probe_all_modules(http_response=None, url=None, body=None, active_keys_map=None, http_client=None, **kwargs):
     """Run active probes against modules whose YARA prefilter matches the response.
 
     Args:
-        httpx_response: The passive HTTP response to prefilter against
-        url: Target URL for active probes (extracted from httpx_response if not provided)
-        body: Response body text (extracted from httpx_response if not provided)
+        http_response: The passive HTTP response to prefilter against
+        url: Target URL for active probes (extracted from http_response if not provided)
+        body: Response body text (extracted from http_response if not provided)
         active_keys_map: Dict of {module_class_name: [key1, key2, ...]} for per-module custom keys
+        http_client: Optional shared HTTP client (e.g. blasthttp.BlastHTTP, blasthttp.mock.BlasthttpMock).
+            If provided, each active module reuses it; otherwise modules create their own.
     Returns:
         List of result dicts from active probes, or empty list
     """
@@ -456,13 +456,13 @@ async def probe_all_modules(httpx_response=None, url=None, body=None, active_key
     # Build scan text including headers + body for prefilter matching
     scan_text = body
     if not scan_text:
-        scan_text = build_prefilter_text(httpx_response=httpx_response, body=body)
+        scan_text = build_prefilter_text(http_response=http_response, body=body)
     if not scan_text:
         return results
 
     # Extract URL from response if not provided
-    if not url and httpx_response is not None:
-        url = str(httpx_response.url)
+    if not url and http_response is not None:
+        url = str(http_response.url)
 
     # Run YARA prefilter
     prefilter_matches = yara_prefilter_scan(scan_text)
@@ -473,7 +473,7 @@ async def probe_all_modules(httpx_response=None, url=None, body=None, active_key
     for cls in _active_subclasses():
         if cls.__name__ in prefilter_matches:
             custom_keys = active_keys_map.get(cls.__name__, [])
-            module = cls()
+            module = cls(http_client=http_client)
             try:
                 probe_results = await module.probe(url, custom_keys=custom_keys, **kwargs)
             except Exception as e:

--- a/badsecrets/examples/blacklist3r.py
+++ b/badsecrets/examples/blacklist3r.py
@@ -7,9 +7,11 @@
 import re
 import os
 import sys
+import asyncio
 import argparse
-import httpx
 import urllib.parse
+
+from blasthttp import BlastHTTP
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
@@ -102,9 +104,20 @@ def main():
         if args.user_agent:
             headers["User-agent"] = args.user_agent
 
+        async def _get():
+            client = BlastHTTP()
+            return await client.request(
+                args.url,
+                method="GET",
+                headers=list(headers.items()),
+                verify_certs=False,
+                follow_redirects=True,
+                proxy=proxy,
+            )
+
         try:
-            res = httpx.get(args.url, proxy=proxy, headers=headers, verify=False, follow_redirects=True)
-        except (httpx.ConnectError, httpx.ConnectTimeout):
+            res = asyncio.run(_get())
+        except RuntimeError:
             print(f"Error connecting to URL: [{args.url}]")
             return
         resp_body = urllib.parse.unquote(res.text)

--- a/badsecrets/examples/cli.py
+++ b/badsecrets/examples/cli.py
@@ -14,7 +14,7 @@ from badsecrets.base import (
     yara_prefilter_scan,
 )
 from badsecrets.helpers import print_status, validate_url
-import httpx
+from blasthttp import BlastHTTP
 import asyncio
 import argparse
 import difflib
@@ -396,40 +396,40 @@ def main():
 
         # Fetch initial response without following redirects, then follow if needed.
         # Both passive and active phases evaluate every response we collect.
-        try:
-            res = httpx.get(
-                args.url,
-                proxy=proxy,
-                headers=headers,
-                verify=False,
-                follow_redirects=False,
+        client = BlastHTTP()
+        header_tuples = list(headers.items())
+
+        async def _get(url, follow_redirects):
+            return await client.request(
+                url,
+                method="GET",
+                headers=header_tuples,
+                verify_certs=False,
+                follow_redirects=follow_redirects,
                 timeout=args.timeout,
+                proxy=proxy,
             )
-        except (httpx.ConnectError, httpx.ConnectTimeout):
+
+        try:
+            res = asyncio.run(_get(args.url, follow_redirects=False))
+        except RuntimeError as e:
             if not json_mode:
-                print_status(f"Error connecting to URL: [{args.url}]", color="red")
+                print_status(f"Error connecting to URL: [{args.url}] ({e})", color="red")
             return
 
         responses = [(res, args.url)]
 
         # If the initial response is a redirect, also fetch the followed page
-        if res.is_redirect:
+        if 300 <= res.status_code < 400:
             try:
-                followed = httpx.get(
-                    args.url,
-                    proxy=proxy,
-                    headers=headers,
-                    verify=False,
-                    follow_redirects=True,
-                    timeout=args.timeout,
-                )
+                followed = asyncio.run(_get(args.url, follow_redirects=True))
                 if args.debug and not json_mode:
                     print_status(
                         f"[DEBUG] Followed redirect to: {followed.url} (status {followed.status_code})",
                         color="blue",
                     )
                 responses.append((followed, str(followed.url)))
-            except (httpx.ConnectError, httpx.ConnectTimeout):
+            except RuntimeError:
                 pass
 
         # Passive phase: carve all responses
@@ -437,12 +437,12 @@ def main():
         for resp, resp_url in responses:
             if args.debug and not json_mode:
                 print_status(f"[DEBUG] Response status: {resp.status_code} ({resp_url})", color="blue")
-                print_status(f"[DEBUG] Response headers: {dict(resp.headers)}", color="blue")
+                print_status(f"[DEBUG] Response headers: {dict(resp.headers.items())}", color="blue")
                 if resp.cookies:
                     print_status(f"[DEBUG] Cookies: {list(resp.cookies.keys())}", color="blue")
                 print_status(f"[DEBUG] Response body length: {len(resp.text)} chars", color="blue")
 
-            r_list = carve_all_modules(httpx_response=resp, custom_resource=custom_resource, url=resp_url)
+            r_list = carve_all_modules(http_response=resp, custom_resource=custom_resource, url=resp_url)
             if r_list:
                 all_passive_results.extend(r_list)
 
@@ -487,7 +487,7 @@ def main():
             active_results = []
             seen_modules = set()
             for resp, resp_url in responses:
-                scan_text = build_prefilter_text(httpx_response=resp)
+                scan_text = build_prefilter_text(http_response=resp)
                 if not scan_text:
                     continue
                 prefilter_matches = yara_prefilter_scan(scan_text)
@@ -504,6 +504,7 @@ def main():
                             body=scan_text,
                             url=resp_url,
                             active_keys_map=active_keys_map,
+                            http_client=client,
                         )
                     )
                     active_results.extend(results)

--- a/badsecrets/examples/symfony_knownkey.py
+++ b/badsecrets/examples/symfony_knownkey.py
@@ -5,10 +5,12 @@
 
 import os
 import sys
+import asyncio
 import hashlib
 import argparse
-import httpx
 from contextlib import suppress
+
+from blasthttp import BlastHTTP
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
@@ -54,17 +56,28 @@ def main():
     if args.user_agent:
         headers["User-agent"] = args.user_agent
 
+    client = BlastHTTP()
+    header_tuples = list(headers.items())
+
+    async def _get(url):
+        return await client.request(
+            url,
+            method="GET",
+            headers=header_tuples,
+            verify_certs=False,
+            follow_redirects=True,
+            proxy=proxy,
+        )
+
     fragment_test_url = f"{args.url.rstrip('/')}/_fragment"
     try:
-        res_fragment = httpx.get(
-            f"{fragment_test_url}", proxy=proxy, headers=headers, verify=False, follow_redirects=True
-        )
-    except (httpx.ConnectError, httpx.ConnectTimeout):
+        res_fragment = asyncio.run(_get(fragment_test_url))
+    except RuntimeError:
         print(f"Error connecting to URL: [{args.url}]")
         return
 
     negative_test_url = f"{args.url.rstrip('/')}/AAAAAAAA"
-    res_random = httpx.get(f"{negative_test_url}", proxy=proxy, headers=headers, verify=False, follow_redirects=True)
+    res_random = asyncio.run(_get(negative_test_url))
 
     if (res_fragment.status_code != 403) or res_random.status_code == res_fragment.status_code:
         print(f"Not a Symfony app, or _fragment functionality not enabled...")
@@ -82,7 +95,7 @@ def main():
             for hash_algorithm in [hashlib.sha256, hashlib.sha1]:
                 hash_value = x.symfonyHMAC(phpinfo_test_url, secret, hash_algorithm)
                 test_url = f"{phpinfo_test_url}&_hash={hash_value.decode()}"
-                test_res = httpx.get(f"{test_url}", proxy=proxy, headers=headers, verify=False, follow_redirects=True)
+                test_res = asyncio.run(_get(test_url))
                 if "PHP Authors" in test_res.text:
                     print(test_url)
                     print(f"Found Symfony Secret! [{secret}]")

--- a/badsecrets/examples/telerik_knownkey.py
+++ b/badsecrets/examples/telerik_knownkey.py
@@ -10,9 +10,73 @@ import string
 import base64
 import random
 import urllib.parse
+import asyncio
 import argparse
-import httpx
 from itertools import chain
+from urllib.parse import urlencode
+
+from blasthttp import BlastHTTP
+
+
+_HTTP_CLIENT = None
+
+
+def _client():
+    global _HTTP_CLIENT
+    if _HTTP_CLIENT is None:
+        _HTTP_CLIENT = BlastHTTP()
+    return _HTTP_CLIENT
+
+
+def _sync_request(url, method="GET", body=None, headers=None, proxy=None, follow_redirects=False, timeout=None):
+    """Synchronous wrapper around blasthttp.BlastHTTP.request via asyncio.run.
+
+    `headers` may be a dict (will be converted to list of tuples) or already a list.
+    """
+    if isinstance(headers, dict):
+        header_tuples = list(headers.items())
+    elif headers is None:
+        header_tuples = []
+    else:
+        header_tuples = list(headers)
+
+    async def _do():
+        kwargs = {
+            "method": method,
+            "headers": header_tuples,
+            "verify_certs": False,
+            "follow_redirects": follow_redirects,
+            "proxy": proxy,
+        }
+        if body is not None:
+            kwargs["body"] = body
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        return await _client().request(url, **kwargs)
+
+    return asyncio.run(_do())
+
+
+def _sync_post_form(url, data, headers=None, proxy=None):
+    """Synchronous form-urlencoded POST."""
+    if not isinstance(headers, dict):
+        headers = dict(headers or [])
+    h = {**headers, "Content-Type": "application/x-www-form-urlencoded"}
+    body = urlencode(data).encode()
+    return _sync_request(url, method="POST", body=body, headers=h, proxy=proxy)
+
+
+def _sync_post_raw(url, content, headers=None, proxy=None):
+    """Synchronous POST with a raw body (e.g. multipart). Caller sets Content-Type in headers."""
+    return _sync_request(url, method="POST", body=content, headers=headers, proxy=proxy)
+
+
+def _sync_get(url, headers=None, proxy=None, follow_redirects=False, timeout=None):
+    """Synchronous GET."""
+    return _sync_request(
+        url, method="GET", headers=headers, proxy=proxy, follow_redirects=follow_redirects, timeout=timeout
+    )
+
 
 from Crypto.Cipher import AES
 from Crypto.Hash import HMAC
@@ -217,9 +281,7 @@ class AsyncUpload:
         data, multipart_boundary = self.rau_data_prep("1985.10.26", derived_key, iv, "ThinkMcFlyThink")
         headers = dict(self.headers) if self.headers else {}
         headers["Content-Type"] = f"multipart/form-data; boundary=---------------------------{multipart_boundary}"
-        request = httpx.Request("POST", self.url, content=data, headers=headers)
-        with httpx.Client(proxy=self.proxy, verify=False) as client:
-            resp = client.send(request)
+        resp = _sync_post_raw(self.url, content=data, headers=headers, proxy=self.proxy)
         if "Exception Details: " in resp.text:
             print("Verbose Errors are enabled!")
             if "Telerik.Web.UI.CryptoExceptionThrower.ThrowGenericCryptoException" in resp.text:
@@ -329,13 +391,11 @@ class AsyncUpload:
                         headers["Content-Type"] = (
                             f"multipart/form-data; boundary=---------------------------{multipart_boundary}"
                         )
-                        request = httpx.Request("POST", self.url, content=data, headers=headers)
                         if hasattr(self, "debug") and self.debug:
                             print(f"[DEBUG] Sending request to: {self.url}")
                         try:
-                            with httpx.Client(proxy=self.proxy, verify=False) as client:
-                                resp = client.send(request)
-                        except httpx.HTTPError:
+                            resp = _sync_post_raw(self.url, content=data, headers=headers, proxy=self.proxy)
+                        except RuntimeError:
                             print(f"Network error connecting to URL: [{self.url}]. Exiting due to connection failure.")
                             sys.exit(1)
                         if hasattr(self, "debug") and self.debug:
@@ -386,14 +446,13 @@ class DialogHandler:
         ct = self.telerik_encryptionkey.telerik_encrypt(derivedKey, derivedIV, plaintext)
         dialog_parameters = self.telerik_hashkey.sign_enc_dialog_params(self.hash_key, ct)
         try:
-            r = httpx.post(
+            r = _sync_post_form(
                 self.url,
                 data={"dialogParametersHolder": dialog_parameters},
                 headers=self.headers,
-                verify=False,
                 proxy=self.proxy,
             )
-        except httpx.HTTPError:
+        except RuntimeError:
             if hasattr(self, "debug") and self.debug:
                 print("[DEBUG] Network error probing version, exiting")
             sys.exit(1)
@@ -418,14 +477,13 @@ class DialogHandler:
         dialog_parameters = self.telerik_hashkey.sign_enc_dialog_params(self.hash_key, ct)
 
         try:
-            r = httpx.post(
+            r = _sync_post_form(
                 self.url,
                 data={"dialogParametersHolder": dialog_parameters},
                 headers=self.headers,
-                verify=False,
                 proxy=self.proxy,
             )
-        except httpx.HTTPError:
+        except RuntimeError:
             if hasattr(self, "debug") and self.debug:
                 print("[DEBUG] Network error probing version, exiting")
             sys.exit(1)
@@ -452,8 +510,8 @@ class DialogHandler:
             print("\n[DEBUG] Detecting key derivation function")
             print(f"[DEBUG] Sending probe request to: {self.url}")
         try:
-            res = httpx.post(self.url, data=KDF_probe_data, proxy=self.proxy, headers=self.headers, verify=False)
-        except httpx.HTTPError:
+            res = _sync_post_form(self.url, data=KDF_probe_data, proxy=self.proxy, headers=self.headers)
+        except RuntimeError:
             print(f"Network error connecting to URL: [{self.url}]. Cannot determine key derivation function.")
             sys.exit(1)
         resp_body = res.text
@@ -504,8 +562,8 @@ class DialogHandler:
                     print(f"[DEBUG] Sending request to: {self.url}")
 
                 try:
-                    res = httpx.post(self.url, data=data, proxy=self.proxy, headers=self.headers, verify=False)
-                except httpx.HTTPError:
+                    res = _sync_post_form(self.url, data=data, proxy=self.proxy, headers=self.headers)
+                except RuntimeError:
                     print(f"Network error connecting to URL: [{self.url}]. Exiting due to connection failure.")
                     sys.exit(1)
 
@@ -547,8 +605,8 @@ class DialogHandler:
                         print(f"\n[DEBUG] Testing encryption key #{encryptionkey_counter}: {encryption_key}")
                         print(f"[DEBUG] Sending request to: {self.url}")
                     try:
-                        res = httpx.post(self.url, data=data, proxy=self.proxy, headers=self.headers, verify=False)
-                    except httpx.HTTPError:
+                        res = _sync_post_form(self.url, data=data, proxy=self.proxy, headers=self.headers)
+                    except RuntimeError:
                         print(f"Network error connecting to URL: [{self.url}]. Exiting due to connection failure.")
                         sys.exit(1)
                     if hasattr(self, "debug") and self.debug:
@@ -587,8 +645,8 @@ class DialogHandler:
             dialog_parameters = self.telerik_hashkey.sign_enc_dialog_params("dummy", ct)
             data = {"dialogParametersHolder": dialog_parameters}
             try:
-                baseline_res = httpx.post(self.url, data=data, proxy=self.proxy, headers=self.headers, verify=False)
-            except httpx.HTTPError:
+                baseline_res = _sync_post_form(self.url, data=data, proxy=self.proxy, headers=self.headers)
+            except RuntimeError:
                 print(f"Network error connecting to URL: [{self.url}]. Cannot establish baseline for testing.")
                 sys.exit(1)
             baseline_size = len(baseline_res.text)
@@ -639,8 +697,8 @@ class DialogHandler:
                         print(f"  - Encryption Key: {encryption_key}")
                         print(f"[DEBUG] Sending request to: {self.url}")
                     try:
-                        res = httpx.post(self.url, data=data, proxy=self.proxy, headers=self.headers, verify=False)
-                    except httpx.HTTPError:
+                        res = _sync_post_form(self.url, data=data, proxy=self.proxy, headers=self.headers)
+                    except RuntimeError:
                         print(f"Network error connecting to URL: [{self.url}]. Exiting due to connection failure.")
                         sys.exit(1)
 
@@ -796,8 +854,8 @@ def main():
         print("Assuming target is a AsyncUpload Endpoint...")
         asyncupload_endpoint = args.url.split("?")[0] + "?type=RAU"
         try:
-            res = httpx.get(asyncupload_endpoint, proxy=proxy, headers=headers, verify=False, timeout=10)
-        except httpx.HTTPError:
+            res = _sync_get(asyncupload_endpoint, proxy=proxy, headers=headers, timeout=10)
+        except RuntimeError:
             print(f"Network error connecting to URL: [{args.url}]. Please check the URL and network connectivity.")
             sys.exit(1)
             return
@@ -840,8 +898,8 @@ def main():
     else:
         print("Assuming target is Telerik UI DialogHandler...")
         try:
-            res = httpx.get(args.url, proxy=proxy, headers=headers, verify=False, follow_redirects=True)
-        except httpx.HTTPError:
+            res = _sync_get(args.url, proxy=proxy, headers=headers, follow_redirects=True)
+        except RuntimeError:
             print(f"Network error connecting to URL: [{args.url}]. Please check the URL and network connectivity.")
             sys.exit(1)
             return

--- a/badsecrets/modules/active/globalprotect.py
+++ b/badsecrets/modules/active/globalprotect.py
@@ -62,7 +62,8 @@ class GlobalProtect_DefaultMasterKey(BadsecretsActiveBase):
             url: Target URL (base URL, path will be replaced with /sslmgr)
             custom_keys: List of additional keys to try
         """
-        import httpx
+        from blasthttp import BlastHTTP
+        from urllib.parse import urlencode
 
         results = []
         # Build target URL: replace path with /sslmgr
@@ -85,75 +86,72 @@ class GlobalProtect_DefaultMasterKey(BadsecretsActiveBase):
                 if key not in keys_to_try:
                     keys_to_try.append(key)
 
-        client = self.http_client
-        should_close = False
-        if client is None:
-            client = httpx.AsyncClient(timeout=10, verify=False)
-            should_close = True
+        client = self.http_client if self.http_client is not None else BlastHTTP()
 
-        try:
-            for key_str in keys_to_try:
-                try:
-                    aes_key = self.derive_aes_key(key_str)
-                    cookie = self.build_auth_cookie(aes_key)
-                    data = {
+        for key_str in keys_to_try:
+            try:
+                aes_key = self.derive_aes_key(key_str)
+                cookie = self.build_auth_cookie(aes_key)
+                form_body = urlencode(
+                    {
                         "scep-profile-name": "badsecrets",
                         "user-email": "probe@badsecrets.local",
                         "user": "badsecrets-probe",
                         "host-id": "badsecrets-hostid",
                         "appauthcookie": cookie,
                     }
-                    response = await client.post(
-                        sslmgr_url,
-                        data=data,
-                        headers={
-                            "User-Agent": "PAN-GlobalProtect",
-                            "Content-Type": "application/x-www-form-urlencoded",
-                        },
-                    )
-                    text = response.text
+                ).encode()
+                response = await client.request(
+                    sslmgr_url,
+                    method="POST",
+                    body=form_body,
+                    headers=[
+                        ("User-Agent", "PAN-GlobalProtect"),
+                        ("Content-Type", "application/x-www-form-urlencoded"),
+                    ],
+                    verify_certs=False,
+                    timeout=10,
+                )
+                text = response.text
 
-                    if "Unable to find the configuration" in text:
-                        is_default = key_str == self.DEFAULT_KEY
-                        results.append(
-                            {
-                                "type": "SecretFound",
-                                "product": sslmgr_url,
-                                "secret": f"{'default' if is_default else key_str} master key ({key_str})",
-                                "location": "active_probe",
-                                "details": {
-                                    "key": key_str,
-                                    "is_default_key": is_default,
-                                    "scep_configured": False,
-                                    "response_indicator": "Unable to find the configuration",
-                                },
-                            }
-                        )
-                    elif "Unable to generate client certificate" in text:
-                        is_default = key_str == self.DEFAULT_KEY
-                        results.append(
-                            {
-                                "type": "SecretFound",
-                                "product": sslmgr_url,
-                                "secret": f"{'default' if is_default else key_str} master key ({key_str})",
-                                "location": "active_probe",
-                                "details": {
-                                    "key": key_str,
-                                    "is_default_key": is_default,
-                                    "scep_configured": True,
-                                    "cve": "CVE-2021-3060",
-                                    "response_indicator": "Unable to generate client certificate",
-                                },
-                            }
-                        )
-                    elif "Invalid Cookie" in text:
-                        log.debug(f"Key '{key_str}' rejected by {sslmgr_url}")
-                    else:
-                        log.debug(f"Unexpected response from {sslmgr_url}: {text[:200]}")
-                except Exception as e:
-                    log.debug(f"Error probing {sslmgr_url} with key '{key_str}': {e}")
-        finally:
-            if should_close:
-                await client.aclose()
+                if "Unable to find the configuration" in text:
+                    is_default = key_str == self.DEFAULT_KEY
+                    results.append(
+                        {
+                            "type": "SecretFound",
+                            "product": sslmgr_url,
+                            "secret": f"{'default' if is_default else key_str} master key ({key_str})",
+                            "location": "active_probe",
+                            "details": {
+                                "key": key_str,
+                                "is_default_key": is_default,
+                                "scep_configured": False,
+                                "response_indicator": "Unable to find the configuration",
+                            },
+                        }
+                    )
+                elif "Unable to generate client certificate" in text:
+                    is_default = key_str == self.DEFAULT_KEY
+                    results.append(
+                        {
+                            "type": "SecretFound",
+                            "product": sslmgr_url,
+                            "secret": f"{'default' if is_default else key_str} master key ({key_str})",
+                            "location": "active_probe",
+                            "details": {
+                                "key": key_str,
+                                "is_default_key": is_default,
+                                "scep_configured": True,
+                                "cve": "CVE-2021-3060",
+                                "response_indicator": "Unable to generate client certificate",
+                            },
+                        }
+                    )
+                elif "Invalid Cookie" in text:
+                    log.debug(f"Key '{key_str}' rejected by {sslmgr_url}")
+                else:
+                    log.debug(f"Unexpected response from {sslmgr_url}: {text[:200]}")
+            except Exception as e:
+                log.debug(f"Error probing {sslmgr_url} with key '{key_str}': {e}")
 
         return results

--- a/badsecrets/modules/active/ltpa_token.py
+++ b/badsecrets/modules/active/ltpa_token.py
@@ -190,7 +190,7 @@ class LTPA_Token_Key(BadsecretsActiveBase):
         2. For each key, forge LtpaToken2, send as cookie
         3. If response is 200 (not redirect/401), the key was accepted
         """
-        import httpx
+        from blasthttp import BlastHTTP
 
         results = []
         base = re.match(r"(https?://[^/]+)", url)
@@ -201,61 +201,55 @@ class LTPA_Token_Key(BadsecretsActiveBase):
         if not keysets:
             return results
 
-        client = self.http_client
-        should_close = False
-        if client is None:
-            client = httpx.AsyncClient(timeout=10, verify=False)
-            should_close = True
+        client = self.http_client if self.http_client is not None else BlastHTTP()
 
+        # Step 1: Confirm target requires authentication
         try:
-            # Step 1: Confirm target requires authentication
-            try:
-                baseline_resp = await client.get(url, follow_redirects=False)
-                if baseline_resp.status_code == 200:
-                    log.debug(f"Target {url} returned 200 without auth — skipping LTPA probe")
-                    return results
-            except Exception as e:
-                log.debug(f"Error checking baseline for {url}: {e}")
+            baseline_resp = await client.request(
+                url, method="GET", follow_redirects=False, verify_certs=False, timeout=10
+            )
+            if baseline_resp.status_code == 200:
+                log.debug(f"Target {url} returned 200 without auth — skipping LTPA probe")
                 return results
+        except Exception as e:
+            log.debug(f"Error checking baseline for {url}: {e}")
+            return results
 
-            # Step 2: Try each keyset
-            for keyset in keysets:
-                try:
-                    token = forge_ltpa2_token(
-                        keyset["aes_key"],
-                        keyset["rsa_key"],
-                        keyset["realm"],
+        # Step 2: Try each keyset
+        for keyset in keysets:
+            try:
+                token = forge_ltpa2_token(
+                    keyset["aes_key"],
+                    keyset["rsa_key"],
+                    keyset["realm"],
+                )
+                response = await client.request(
+                    url,
+                    method="GET",
+                    headers=[("Cookie", f"LtpaToken2={token}")],
+                    follow_redirects=False,
+                    verify_certs=False,
+                    timeout=10,
+                )
+
+                if response.status_code == 200:
+                    log.debug(f"Forged LtpaToken2 accepted by {url}: LtpaToken2={token}")
+                    results.append(
+                        {
+                            "type": "SecretFound",
+                            "product": url,
+                            "secret": f"LtpaToken2 key {keyset['key_id']} (see ltpa_active_keys.json)",
+                            "location": "active_probe",
+                            "details": {
+                                "key_id": keyset["key_id"],
+                                "key_source": keyset["source"],
+                                "realm": keyset["realm"],
+                            },
+                        }
                     )
-                    response = await client.get(
-                        url,
-                        headers={"Cookie": f"LtpaToken2={token}"},
-                        follow_redirects=False,
-                    )
-
-                    if response.status_code == 200:
-                        log.debug(f"Forged LtpaToken2 accepted by {url}: LtpaToken2={token}")
-                        results.append(
-                            {
-                                "type": "SecretFound",
-                                "product": url,
-                                "secret": f"LtpaToken2 key {keyset['key_id']} (see ltpa_active_keys.json)",
-                                "location": "active_probe",
-                                "details": {
-                                    "key_id": keyset["key_id"],
-                                    "key_source": keyset["source"],
-                                    "realm": keyset["realm"],
-                                },
-                            }
-                        )
-                    else:
-                        log.debug(
-                            f"LTPA key from {keyset['source']} rejected by {url} (status {response.status_code})"
-                        )
-                except Exception as e:
-                    log.debug(f"Error probing {url} with LTPA key from {keyset['source']}: {e}")
-
-        finally:
-            if should_close:
-                await client.aclose()
+                else:
+                    log.debug(f"LTPA key from {keyset['source']} rejected by {url} (status {response.status_code})")
+            except Exception as e:
+                log.debug(f"Error probing {url} with LTPA key from {keyset['source']}: {e}")
 
         return results

--- a/badsecrets/modules/active/shiro_rememberme.py
+++ b/badsecrets/modules/active/shiro_rememberme.py
@@ -65,7 +65,9 @@ class Shiro_RememberMe_Key(BadsecretsActiveBase):
     @staticmethod
     def _has_delete_me(response):
         """Check if response contains rememberMe=deleteMe in Set-Cookie."""
-        return any("rememberMe=deleteMe" in value for value in response.headers.get_list("set-cookie"))
+        return any(
+            name.lower() == "set-cookie" and "rememberMe=deleteMe" in value for name, value in response.headers.items()
+        )
 
     async def probe(self, url, custom_keys=None, **kwargs):
         """Probe for known Shiro rememberMe keys by sending crafted cookies.
@@ -75,7 +77,7 @@ class Shiro_RememberMe_Key(BadsecretsActiveBase):
         2. For each candidate key, encrypt a SimplePrincipalCollection with AES-CBC then AES-GCM
         3. If response does NOT contain deleteMe, the key is correct
         """
-        import httpx
+        from blasthttp import BlastHTTP
 
         results = []
         base = re.match(r"(https?://[^/]+)", url)
@@ -100,48 +102,42 @@ class Shiro_RememberMe_Key(BadsecretsActiveBase):
                 if key not in keys_to_try:
                     keys_to_try.append(key)
 
-        client = self.http_client
-        should_close = False
-        if client is None:
-            client = httpx.AsyncClient(timeout=10, verify=False)
-            should_close = True
+        client = self.http_client if self.http_client is not None else BlastHTTP()
 
+        # Step 1: Confirm Shiro is present by sending garbage cookie
         try:
-            # Step 1: Confirm Shiro is present by sending garbage cookie
-            try:
-                confirm_resp = await client.get(
-                    target_url,
-                    headers={"Cookie": "rememberMe=1"},
-                    follow_redirects=True,
-                )
-                if not self._has_delete_me(confirm_resp):
-                    log.debug(f"Shiro confirmation failed: no deleteMe in response from {target_url}")
-                    return results
-            except Exception as e:
-                log.debug(f"Error confirming Shiro at {target_url}: {e}")
+            confirm_resp = await client.request(
+                target_url,
+                method="GET",
+                headers=[("Cookie", "rememberMe=1")],
+                follow_redirects=True,
+                verify_certs=False,
+                timeout=10,
+            )
+            if not self._has_delete_me(confirm_resp):
+                log.debug(f"Shiro confirmation failed: no deleteMe in response from {target_url}")
                 return results
+        except Exception as e:
+            log.debug(f"Error confirming Shiro at {target_url}: {e}")
+            return results
 
-            # Step 2: Try each key
-            for key_b64 in keys_to_try:
-                with suppress(ValueError, binascii.Error):
-                    key_bytes = base64.b64decode(key_b64)
-                    if len(key_bytes) not in (16, 24, 32):
-                        continue
+        # Step 2: Try each key
+        for key_b64 in keys_to_try:
+            with suppress(ValueError, binascii.Error):
+                key_bytes = base64.b64decode(key_b64)
+                if len(key_bytes) not in (16, 24, 32):
+                    continue
 
-                    # Try CBC mode first (Shiro < 1.4.2)
-                    result = await self._try_key(client, target_url, key_bytes, key_b64, mode="CBC")
-                    if result:
-                        results.append(result)
-                        continue
+                # Try CBC mode first (Shiro < 1.4.2)
+                result = await self._try_key(client, target_url, key_bytes, key_b64, mode="CBC")
+                if result:
+                    results.append(result)
+                    continue
 
-                    # Try GCM mode (Shiro >= 1.4.2)
-                    result = await self._try_key(client, target_url, key_bytes, key_b64, mode="GCM")
-                    if result:
-                        results.append(result)
-
-        finally:
-            if should_close:
-                await client.aclose()
+                # Try GCM mode (Shiro >= 1.4.2)
+                result = await self._try_key(client, target_url, key_bytes, key_b64, mode="GCM")
+                if result:
+                    results.append(result)
 
         return results
 
@@ -155,10 +151,13 @@ class Shiro_RememberMe_Key(BadsecretsActiveBase):
 
             cookie_value = base64.b64encode(raw).decode()
 
-            response = await client.get(
+            response = await client.request(
                 url,
-                headers={"Cookie": f"rememberMe={cookie_value}"},
+                method="GET",
+                headers=[("Cookie", f"rememberMe={cookie_value}")],
                 follow_redirects=True,
+                verify_certs=False,
+                timeout=10,
             )
 
             if not self._has_delete_me(response):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "flask-unsign>=1.2.1",
     "Django>=4.1.2,<6.0.0",
     "pyjwt[crypto]>=2.6.0",
-    "httpx>=0.27,<1.0",
+    "blasthttp>=0.5.1",
     "colorama>=0.4.6",
     "yara-python>=4.2.0",
 ]
@@ -27,8 +27,8 @@ symfony-knownkey = "badsecrets.examples.symfony_knownkey:main"
 
 [dependency-groups]
 dev = [
-    "respx>=0.21,<1.0",
     "pytest>=8.3.4,<10.0.0",
+    "pytest-asyncio>=0.21,<2.0",
     "pytest-cov>=6.1.1,<8.0.0",
     "mock>=5.1.0",
     "pytest-mock>=3.10.0",

--- a/tests/active_base_test.py
+++ b/tests/active_base_test.py
@@ -1,7 +1,6 @@
 import asyncio
 import unittest.mock as mock
-import httpx
-import respx
+from blasthttp.mock import BlasthttpMock
 from badsecrets.base import (
     BadsecretsBase,
     BadsecretsActiveBase,
@@ -139,26 +138,24 @@ def test_probe_all_modules_no_body_no_response():
     assert results == []
 
 
-@respx.mock
 def test_probe_all_modules_url_from_response():
-    """probe_all_modules extracts URL from httpx_response when url not provided."""
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
-    )
+    """probe_all_modules extracts URL from http_response when url not provided."""
 
-    mock_response = httpx.Response(
-        200,
-        text="<html>GlobalProtect Portal</html>",
-        request=httpx.Request("GET", "https://vpn.example.com/login"),
-    )
+    class FakeResponse:
+        url = "https://vpn.example.com/login"
+        text = "<html>GlobalProtect Portal</html>"
+        headers = {}
+        cookies = {}
 
-    # url=None forces extraction from httpx_response.url
-    results = asyncio.run(probe_all_modules(httpx_response=mock_response))
+    bh_mock = BlasthttpMock()
+    bh_mock.add_response(url="https://vpn.example.com/sslmgr", text="Unable to find the configuration")
+
+    # url=None forces extraction from http_response.url
+    results = asyncio.run(probe_all_modules(http_response=FakeResponse(), http_client=bh_mock))
     assert len(results) >= 1
     assert results[0]["detecting_module"] == "GlobalProtect_DefaultMasterKey"
 
 
-@respx.mock
 def test_probe_all_modules_exception_in_probe():
     """Exception during active probe doesn't crash probe_all_modules."""
 

--- a/tests/all_modules_test.py
+++ b/tests/all_modules_test.py
@@ -1,8 +1,16 @@
-import httpx
-import respx
-
 from badsecrets.base import check_all_modules, carve_all_modules, BadsecretsBase, yara_carve_scan, _all_subclasses
 import badsecrets.base
+
+
+class FakeResponse:
+    """Duck-typed HTTP response for carve(http_response=...) tests."""
+
+    def __init__(self, text="", headers=None, cookies=None, url=""):
+        self.text = text
+        self.headers = headers if headers is not None else {}
+        self.cookies = cookies if cookies is not None else {}
+        self.url = url
+
 
 tests = [
     "yJrdyJV6tkmHLII2uDq1Sl509UeDg9xGI4u3tb6dm9BQS4wD08KTkyXKST4PeQs00giqSA==",
@@ -91,12 +99,10 @@ def test_carve_all_body():
         r_list = carve_all_modules(body=sample)
         assert len(r_list) > 0
 
-    with respx.mock:
-        for idx, sample in enumerate([aspnet_viewstate_sample, telerik_dialogparameters_sample, jwt_html]):
-            respx.get(f"http://{idx}.carve-all.badsecrets.com/").respond(status_code=200, text=sample)
-            res = httpx.get(f"http://{idx}.carve-all.badsecrets.com/")
-            r_list = carve_all_modules(httpx_response=res)
-            assert len(r_list) > 0
+    for sample in [aspnet_viewstate_sample, telerik_dialogparameters_sample, jwt_html]:
+        res = FakeResponse(text=sample)
+        r_list = carve_all_modules(http_response=res)
+        assert len(r_list) > 0
 
 
 def test_carve_all_cookies():
@@ -113,9 +119,6 @@ def test_carve_all_cookies():
     }
 
     # Test cookie carving by passing cookies directly to carve_all_modules.
-    # respx exposes cookies as set-cookie response headers which the carve function
-    # also scans, leading to duplicate detections via mock HTTP responses.
-    # Since this test verifies cookie-based secret detection, we pass cookies directly.
     r_list = carve_all_modules(cookies=cookies)
     assert len(r_list) == 7
 
@@ -128,15 +131,9 @@ def test_carve_multiple_vulns():
 <input type="hidden" name="__VIEWSTATEGENERATOR" value="AAAAAAAA" />
 """
 
-    with respx.mock:
-        respx.get("http://multiplevulns.carve-all.badsecrets.com/").respond(
-            status_code=200,
-            text=multiple_vuln_html,
-        )
-
-        res = httpx.get("http://multiplevulns.carve-all.badsecrets.com/")
-        r_list = carve_all_modules(httpx_response=res)
-        assert len(r_list) == 2
+    res = FakeResponse(text=multiple_vuln_html)
+    r_list = carve_all_modules(http_response=res)
+    assert len(r_list) == 2
 
 
 def test_multiple_identify_only():
@@ -150,19 +147,13 @@ Sys.Application.add_init(function() {
 </body>
 </html>
 """
-    with respx.mock:
-        respx.get("http://multipleidentifyonly.carve-all.badsecrets.com/").respond(
-            status_code=200,
-            text=multiple_identify_only_html,
-        )
-
-        res = httpx.get("http://multipleidentifyonly.carve-all.badsecrets.com/")
-        r_list = carve_all_modules(httpx_response=res)
-        assert len(r_list) == 2
-        assert r_list[0]["type"] == "IdentifyOnly"
-        assert r_list[1]["type"] == "IdentifyOnly"
-        assert r_list[0]["description"]["product"] in ["Telerik DialogParameters", "Telerik Hash Key Signature"]
-        assert r_list[1]["description"]["product"] in ["Telerik DialogParameters", "Telerik Hash Key Signature"]
+    res = FakeResponse(text=multiple_identify_only_html)
+    r_list = carve_all_modules(http_response=res)
+    assert len(r_list) == 2
+    assert r_list[0]["type"] == "IdentifyOnly"
+    assert r_list[1]["type"] == "IdentifyOnly"
+    assert r_list[0]["description"]["product"] in ["Telerik DialogParameters", "Telerik Hash Key Signature"]
+    assert r_list[1]["description"]["product"] in ["Telerik DialogParameters", "Telerik Hash Key Signature"]
 
 
 def test_yara_carve_coverage():

--- a/tests/aspnet_viewstate_test.py
+++ b/tests/aspnet_viewstate_test.py
@@ -449,27 +449,30 @@ def test_normal_viewstate_carve_still_works():
 
 
 def test_carve_no_args():
-    """carve() with no args should raise CarveException (lines 68-70)."""
+    """carve() with no args should raise CarveException."""
     x = ASPNETViewstate()
-    with pytest.raises(CarveException, match="Either body/headers/cookies or httpx_response required"):
+    with pytest.raises(CarveException, match="Either body/headers/cookies or http_response required"):
         x.carve()
 
 
-def test_carve_httpx_response_with_body():
-    """carve() with both httpx_response and body should raise CarveException (lines 74-76)."""
-    import httpx
+def test_carve_http_response_with_body():
+    """carve() with both http_response and body should raise CarveException."""
+
+    class FakeResponse:
+        text = "<html></html>"
+        headers = {}
+        cookies = {}
 
     x = ASPNETViewstate()
-    response = httpx.Response(200, text="<html></html>")
     with pytest.raises(CarveException, match="cannot both be set"):
-        x.carve(httpx_response=response, body="<html></html>")
+        x.carve(http_response=FakeResponse(), body="<html></html>")
 
 
-def test_carve_httpx_response_invalid_type():
-    """carve() with non-httpx.Response should raise CarveException (lines 88-90)."""
+def test_carve_http_response_invalid_type():
+    """carve() with object missing required attrs should raise CarveException."""
     x = ASPNETViewstate()
-    with pytest.raises(CarveException, match="must be an httpx.Response"):
-        x.carve(httpx_response="not a response")
+    with pytest.raises(CarveException, match="must expose .text, .headers, and .cookies"):
+        x.carve(http_response="not a response")
 
 
 def test_carve_cookies_not_dict():
@@ -616,19 +619,20 @@ def test_carve_to_check_secret_direct_returns_none():
     assert result is None
 
 
-def test_carve_mock_httpx_response():
-    """carve() with a mock httpx.Response extracts cookies, headers, body (lines 81-86)."""
-    import httpx
+def test_carve_mock_http_response():
+    """carve() with a mock http response extracts cookies, headers, body."""
 
-    x = ASPNETViewstate()
-    html_body = """
+    class FakeResponse:
+        url = "http://10.1.1.43/default2.aspx"
+        text = """
     <input type="hidden" name="__VIEWSTATE" value="/wEPDwUJODc0MjgwMjkwZGTCdzCrBtl0AFYdKsWX1bQ8DcMilw==" />
     <input type="hidden" name="__VIEWSTATEGENERATOR" value="9BD98A7D" />
     """
-    # Construct a synthetic httpx.Response in-memory (no network, no server)
-    mock_request = httpx.Request("GET", "http://10.1.1.43/default2.aspx")
-    mock_response = httpx.Response(200, text=html_body, request=mock_request)
-    r_list = x.carve(httpx_response=mock_response, url="http://10.1.1.43/default2.aspx")
+        headers = {}
+        cookies = {}
+
+    x = ASPNETViewstate()
+    r_list = x.carve(http_response=FakeResponse(), url="http://10.1.1.43/default2.aspx")
     assert r_list
     found_secret = any(r["type"] == "SecretFound" for r in r_list)
     assert found_secret

--- a/tests/carve_test.py
+++ b/tests/carve_test.py
@@ -1,9 +1,18 @@
 import pytest
-import httpx
-import respx
 import badsecrets.errors
 
 from badsecrets import modules_loaded
+
+
+class FakeResponse:
+    """Duck-typed HTTP response for carve(http_response=...) tests."""
+
+    def __init__(self, text="", headers=None, cookies=None, url=""):
+        self.text = text
+        self.headers = headers if headers is not None else {}
+        self.cookies = cookies if cookies is not None else {}
+        self.url = url
+
 
 Django_SignedCookies = modules_loaded["django_signedcookies"]
 ASPNET_Viewstate = modules_loaded["aspnet_viewstate"]
@@ -104,195 +113,145 @@ def test_carve_telerik():
 
 
 def test_carve_headers():
-    with respx.mock:
-        x = Generic_JWT()
+    x = Generic_JWT()
 
-        test_headers_vuln = {
-            "auth_jwt": "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.ovqRikAo_0kKJ0GVrAwQlezymxrLGjcEiW_s3UJMMCo"
-        }
-        respx.get("http://vuln.headerscarve.badsecrets.com/").respond(
-            status_code=200,
-            headers=test_headers_vuln,
-            text="<html><p>Some HTML Content</p></html>",
-        )
+    test_headers_vuln = {
+        "auth_jwt": "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.ovqRikAo_0kKJ0GVrAwQlezymxrLGjcEiW_s3UJMMCo"
+    }
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", headers=test_headers_vuln)
+    r = x.carve(http_response=res)
 
-        res = httpx.get("http://vuln.headerscarve.badsecrets.com/")
-        r = x.carve(httpx_response=res)
+    print(r)
+    assert len(r) > 0
+    assert r[0]["type"] == "SecretFound"
+    assert r[0]["secret"] == "1234"
 
-        print(r)
-        assert len(r) > 0
-        assert r[0]["type"] == "SecretFound"
-        assert r[0]["secret"] == "1234"
+    test_headers_notvuln = {
+        "auth_jwt": "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.ovqRikAo_0kKJ0GVrAwQlezymxrLGjcEiW_s3UJMMCA"
+    }
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", headers=test_headers_notvuln)
+    r = x.carve(http_response=res)
 
-        test_headers_notvuln = {
-            "auth_jwt": "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.ovqRikAo_0kKJ0GVrAwQlezymxrLGjcEiW_s3UJMMCA"
-        }
-        respx.get("http://notvuln.headerscarve.badsecrets.com/").respond(
-            status_code=200,
-            headers=test_headers_notvuln,
-            text="<html><p>Some HTML Content</p></html>",
-        )
-
-        res = httpx.get("http://notvuln.headerscarve.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-
-        print(r)
-        assert len(r) > 0
-        assert r[0]["type"] == "IdentifyOnly"
+    print(r)
+    assert len(r) > 0
+    assert r[0]["type"] == "IdentifyOnly"
 
 
 def test_carve_cookies():
-    with respx.mock:
-        # peoplesoft_pstoken
-        x = Peoplesoft_PSToken()
+    # peoplesoft_pstoken
+    x = Peoplesoft_PSToken()
 
-        cookies = {
-            "random-cookie": "useless_data",
-            "PS_TOKEN": "qAAAAAQDAgEBAAAAvAIAAAAAAAAsAAAABABTaGRyAk4AdQg4AC4AMQAwABT5mYioG/i325GsBHHNyDIM+9yf1GgAAAAFAFNkYXRhXHicHYfJDUBQAESfJY5O2iDWgwIsJxHcxdaApTvFGX8mefPmAVzHtizta2MSrCzsXBxsnOIt9yo6GvyekZqJmZaBPCUmVUMS2c9MjCmJKLSR/u+laUGuzwdaGw3o",
-            "random-cookie2": "useless_data2",
-        }
+    cookies = {
+        "random-cookie": "useless_data",
+        "PS_TOKEN": "qAAAAAQDAgEBAAAAvAIAAAAAAAAsAAAABABTaGRyAk4AdQg4AC4AMQAwABT5mYioG/i325GsBHHNyDIM+9yf1GgAAAAFAFNkYXRhXHicHYfJDUBQAESfJY5O2iDWgwIsJxHcxdaApTvFGX8mefPmAVzHtizta2MSrCzsXBxsnOIt9yo6GvyekZqJmZaBPCUmVUMS2c9MjCmJKLSR/u+laUGuzwdaGw3o",
+        "random-cookie2": "useless_data2",
+    }
 
-        cookie_headers = [("set-cookie", f"{k}={v}") for k, v in cookies.items()]
-        respx.get("http://ps_token.badsecrets.com/").mock(
-            return_value=httpx.Response(200, text="<html><p>Some HTML Content</p></html>", headers=cookie_headers)
-        )
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", cookies=cookies)
+    r = x.carve(http_response=res)
+    print(r)
+    assert len(r) > 0
+    assert r[0]["secret"] == "Username: badsecrets Password: password"
 
-        res = httpx.get("http://ps_token.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        print(r)
-        assert len(r) > 0
-        assert r[0]["secret"] == "Username: badsecrets Password: password"
+    # django_signedcookies
+    x = Django_SignedCookies()
 
-        # django_signedcookies
-        x = Django_SignedCookies()
+    cookies = {
+        "random-cookie": "useless_data",
+        "django_session": ".eJxVjLsOAiEURP-F2hAuL8HSfr-BAPciq4ZNlt3K-O9KsoU2U8w5My8W4r7VsHdaw4zswoCdfrsU84PaAHiP7bbwvLRtnRMfCj9o59OC9Lwe7t9Bjb2OtbMkAEGQtQjekykmJy9JZIW-6CgUaCGsA6eSyV65s1Qya_xGKZrY-wPVYjdw:1ojOrE:bfOktjgLlUykwCIRIpvaTZRQMM3-UypscEN57ECtXis",
+        "random-cookie2": "useless_data2",
+    }
 
-        cookies = {
-            "random-cookie": "useless_data",
-            "django_session": ".eJxVjLsOAiEURP-F2hAuL8HSfr-BAPciq4ZNlt3K-O9KsoU2U8w5My8W4r7VsHdaw4zswoCdfrsU84PaAHiP7bbwvLRtnRMfCj9o59OC9Lwe7t9Bjb2OtbMkAEGQtQjekykmJy9JZIW-6CgUaCGsA6eSyV65s1Qya_xGKZrY-wPVYjdw:1ojOrE:bfOktjgLlUykwCIRIpvaTZRQMM3-UypscEN57ECtXis",
-            "random-cookie2": "useless_data2",
-        }
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", cookies=cookies)
+    r = x.carve(http_response=res)
+    print(r)
+    assert len(r) > 0
+    assert r[0]["details"]["_auth_user_hash"] == "d86e01d10e66d199e5f5cb92e0c3d9f4a03140068183b5c9387232c4d32cff4e"
 
-        cookie_headers = [("set-cookie", f"{k}={v}") for k, v in cookies.items()]
-        respx.get("http://django.badsecrets.com/").mock(
-            return_value=httpx.Response(200, text="<html><p>Some HTML Content</p></html>", headers=cookie_headers)
-        )
+    # flash_signedcookies
+    x = Flask_SignedCookies()
 
-        res = httpx.get("http://django.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        print(r)
-        assert len(r) > 0
-        assert r[0]["details"]["_auth_user_hash"] == "d86e01d10e66d199e5f5cb92e0c3d9f4a03140068183b5c9387232c4d32cff4e"
+    cookies = {
+        "random-cookie": "useless_data",
+        "flask_session": "eyJoZWxsbyI6IndvcmxkIn0.XDtqeQ.1qsBdjyRJLokwRzJdzXMVCSyRTA",
+        "random-cookie2": "useless_data2",
+    }
 
-        # flash_signedcookies
-        x = Flask_SignedCookies()
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", cookies=cookies)
+    r = x.carve(http_response=res)
+    print(r)
+    assert len(r) > 0
+    assert r[0]["secret"] == "CHANGEME"
 
-        cookies = {
-            "random-cookie": "useless_data",
-            "flask_session": "eyJoZWxsbyI6IndvcmxkIn0.XDtqeQ.1qsBdjyRJLokwRzJdzXMVCSyRTA",
-            "random-cookie2": "useless_data2",
-        }
+    # rails_secretkeybase
+    x = Rails_SecretKeyBase()
 
-        cookie_headers = [("set-cookie", f"{k}={v}") for k, v in cookies.items()]
-        respx.get("http://flask.badsecrets.com/").mock(
-            return_value=httpx.Response(200, text="<html><p>Some HTML Content</p></html>", headers=cookie_headers)
-        )
+    cookies = {
+        "random-cookie": "useless_data",
+        "rails_session": "eyJfcmFpbHMiOnsibWVzc2FnZSI6IklraGxiR3h2TENCSklHRnRJR0VnYzJsbmJtVmtJSEpoYVd4ek5pQkRiMjlyYVdVaElnPT0iLCJleHAiOm51bGwsInB1ciI6ImNvb2tpZS5zaWduZWQifX0%3D--eb1ea3ddc55deb16ffc58ac165edfbb554067edc",
+        "random-cookie2": "useless_data2",
+    }
 
-        res = httpx.get("http://flask.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        print(r)
-        assert len(r) > 0
-        assert r[0]["secret"] == "CHANGEME"
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", cookies=cookies)
+    r = x.carve(http_response=res)
+    print(r)
+    assert len(r) > 0
+    assert (
+        r[0]["secret"]
+        == "4698bc5d99f3103ca76ab57f28a6b8f75f5f0768aab4f2e3f3743383594ad91f43e78c1b86138602f5859a811927698180ebfae7c490333f37b87521ca5a5f8c"
+    )
 
-        # rails_secretkeybase
-        x = Rails_SecretKeyBase()
+    # generic_jwt
+    x = Generic_JWT()
 
-        cookies = {
-            "random-cookie": "useless_data",
-            "rails_session": "eyJfcmFpbHMiOnsibWVzc2FnZSI6IklraGxiR3h2TENCSklHRnRJR0VnYzJsbmJtVmtJSEpoYVd4ek5pQkRiMjlyYVdVaElnPT0iLCJleHAiOm51bGwsInB1ciI6ImNvb2tpZS5zaWduZWQifX0%3D--eb1ea3ddc55deb16ffc58ac165edfbb554067edc",
-            "random-cookie2": "useless_data2",
-        }
+    cookies = {
+        "random-cookie": "useless_data",
+        "auth": "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.ovqRikAo_0kKJ0GVrAwQlezymxrLGjcEiW_s3UJMMCo",
+        "random-cookie2": "useless_data2",
+    }
 
-        cookie_headers = [("set-cookie", f"{k}={v}") for k, v in cookies.items()]
-        respx.get("http://rails.badsecrets.com/").mock(
-            return_value=httpx.Response(200, text="<html><p>Some HTML Content</p></html>", headers=cookie_headers)
-        )
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", cookies=cookies)
+    r = x.carve(http_response=res)
+    print(r)
+    assert len(r) > 0
+    assert r[0]["secret"] == "1234"
 
-        res = httpx.get("http://rails.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        print(r)
-        assert len(r) > 0
-        assert (
-            r[0]["secret"]
-            == "4698bc5d99f3103ca76ab57f28a6b8f75f5f0768aab4f2e3f3743383594ad91f43e78c1b86138602f5859a811927698180ebfae7c490333f37b87521ca5a5f8c"
-        )
+    cookies = {
+        "random-cookie": "useless_data",
+        "auth": "eyJhbGciOiJSUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.VY5gbfqc1nrTMz7oCFvFBZtHE_gb97dWBAsOG9NJeeXJhASEBe2srxVqbWw1HTGcyZc1oxzJU6o-fpPAEpNO4QhFEJNZbWYJBLMtggiu_MKBEHGHgrAOE9gtH2qUKZ6zMWq5hO3JA0QuIWKE3g342C-beBNoLJ8ph02yrrqYuCWg2smExg6wL_LK0gnpsNLBXRcJ2dYSlEn9tz9Aim5TioZVJZK1DVtBX8k4xA0k47i9DGNwII7R9SU2cqqDOXBd7oo8AYwGP1U4kWtzeTKBBIAEjwGh11yKIMkZrL1SkctWEY1ogFlxBG9dWn0BcrYCVJaIxTSMCGmpjRSUKPnkTg",
+        "random-cookie2": "useless_data2",
+    }
 
-        # generic_jwt
-        x = Generic_JWT()
-
-        cookies = {
-            "random-cookie": "useless_data",
-            "auth": "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.ovqRikAo_0kKJ0GVrAwQlezymxrLGjcEiW_s3UJMMCo",
-            "random-cookie2": "useless_data2",
-        }
-
-        cookie_headers = [("set-cookie", f"{k}={v}") for k, v in cookies.items()]
-        respx.get("http://hmac.generic-jwt.badsecrets.com/").mock(
-            return_value=httpx.Response(200, text="<html><p>Some HTML Content</p></html>", headers=cookie_headers)
-        )
-
-        res = httpx.get("http://hmac.generic-jwt.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        print(r)
-        assert len(r) > 0
-        assert r[0]["secret"] == "1234"
-
-        cookies = {
-            "random-cookie": "useless_data",
-            "auth": "eyJhbGciOiJSUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.VY5gbfqc1nrTMz7oCFvFBZtHE_gb97dWBAsOG9NJeeXJhASEBe2srxVqbWw1HTGcyZc1oxzJU6o-fpPAEpNO4QhFEJNZbWYJBLMtggiu_MKBEHGHgrAOE9gtH2qUKZ6zMWq5hO3JA0QuIWKE3g342C-beBNoLJ8ph02yrrqYuCWg2smExg6wL_LK0gnpsNLBXRcJ2dYSlEn9tz9Aim5TioZVJZK1DVtBX8k4xA0k47i9DGNwII7R9SU2cqqDOXBd7oo8AYwGP1U4kWtzeTKBBIAEjwGh11yKIMkZrL1SkctWEY1ogFlxBG9dWn0BcrYCVJaIxTSMCGmpjRSUKPnkTg",
-            "random-cookie2": "useless_data2",
-        }
-
-        cookie_headers = [("set-cookie", f"{k}={v}") for k, v in cookies.items()]
-        respx.get("http://rsa.generic-jwt.badsecrets.com/").mock(
-            return_value=httpx.Response(200, text="<html><p>Some HTML Content</p></html>", headers=cookie_headers)
-        )
-
-        res = httpx.get("http://rsa.generic-jwt.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        print(r)
-        assert len(r) > 0
-        assert r[0]["secret"] == "Private key Name: 1"
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", cookies=cookies)
+    r = x.carve(http_response=res)
+    print(r)
+    assert len(r) > 0
+    assert r[0]["secret"] == "Private key Name: 1"
 
 
 def test_multiple_results():
-    with respx.mock:
-        # rails_secretkeybase
-        x = Rails_SecretKeyBase()
+    # rails_secretkeybase
+    x = Rails_SecretKeyBase()
 
-        cookies = {
-            "random-cookie": "useless_data",
-            "rails_session": "eyJfcmFpbHMiOnsibWVzc2FnZSI6IklraGxiR3h2TENCSklHRnRJR0VnYzJsbmJtVmtJSEpoYVd4ek5pQkRiMjlyYVdVaElnPT0iLCJleHAiOm51bGwsInB1ciI6ImNvb2tpZS5zaWduZWQifX0%3D--eb1ea3ddc55deb16ffc58ac165edfbb554067edc",
-            "random-cookie2": "useless_data2",
-            "rails_session_2": "fuP54C4UxMudlZRR6j25zJfkevHVZ6IJR6Hp1B3rW6sAW5Aqc1j2Ri0XgcyLRvuSNVLwzq6cqeWlVhwU13xMS8scjU%2BSGGi%2Bta4jQU7oYujKdxynHSEiYOmeNFW4onXoF3KLlmr7ODmtIaHm1zIEP11TT%2FmRqZuxxecjz0VIxUDhvHYEFQ%3D%3D--ZclUs5zZFu3JPKnx--%2Fc0Q4ufTHqqmMxoin0mRtQ%3D%3D",
-        }
+    cookies = {
+        "random-cookie": "useless_data",
+        "rails_session": "eyJfcmFpbHMiOnsibWVzc2FnZSI6IklraGxiR3h2TENCSklHRnRJR0VnYzJsbmJtVmtJSEpoYVd4ek5pQkRiMjlyYVdVaElnPT0iLCJleHAiOm51bGwsInB1ciI6ImNvb2tpZS5zaWduZWQifX0%3D--eb1ea3ddc55deb16ffc58ac165edfbb554067edc",
+        "random-cookie2": "useless_data2",
+        "rails_session_2": "fuP54C4UxMudlZRR6j25zJfkevHVZ6IJR6Hp1B3rW6sAW5Aqc1j2Ri0XgcyLRvuSNVLwzq6cqeWlVhwU13xMS8scjU%2BSGGi%2Bta4jQU7oYujKdxynHSEiYOmeNFW4onXoF3KLlmr7ODmtIaHm1zIEP11TT%2FmRqZuxxecjz0VIxUDhvHYEFQ%3D%3D--ZclUs5zZFu3JPKnx--%2Fc0Q4ufTHqqmMxoin0mRtQ%3D%3D",
+    }
 
-        cookie_headers = [("set-cookie", f"{k}={v}") for k, v in cookies.items()]
-        respx.get("http://rails.badsecrets.com/").mock(
-            return_value=httpx.Response(200, text="<html><p>Some HTML Content</p></html>", headers=cookie_headers)
-        )
-
-        res = httpx.get("http://rails.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        print(r)
-        assert len(r) == 2
-        assert (
-            r[0]["secret"]
-            == "4698bc5d99f3103ca76ab57f28a6b8f75f5f0768aab4f2e3f3743383594ad91f43e78c1b86138602f5859a811927698180ebfae7c490333f37b87521ca5a5f8c"
-        )
-        assert (
-            r[1]["secret"]
-            == "4698bc5d99f3103ca76ab57f28a6b8f75f5f0768aab4f2e3f3743383594ad91f43e78c1b86138602f5859a811927698180ebfae7c490333f37b87521ca5a5f8c"
-        )
+    res = FakeResponse(text="<html><p>Some HTML Content</p></html>", cookies=cookies)
+    r = x.carve(http_response=res)
+    print(r)
+    assert len(r) == 2
+    assert (
+        r[0]["secret"]
+        == "4698bc5d99f3103ca76ab57f28a6b8f75f5f0768aab4f2e3f3743383594ad91f43e78c1b86138602f5859a811927698180ebfae7c490333f37b87521ca5a5f8c"
+    )
+    assert (
+        r[1]["secret"]
+        == "4698bc5d99f3103ca76ab57f28a6b8f75f5f0768aab4f2e3f3743383594ad91f43e78c1b86138602f5859a811927698180ebfae7c490333f37b87521ca5a5f8c"
+    )
 
 
 def test_generic_jwt_body_carve():
@@ -310,17 +269,12 @@ def test_generic_jwt_body_carve():
 </html>
 """
 
-    with respx.mock:
-        x = Generic_JWT()
-        respx.get("http://body.generic-jwt.badsecrets.com/").respond(
-            status_code=200,
-            text=jwt_html,
-        )
-        res = httpx.get("http://body.generic-jwt.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        assert r
-        assert r[0]["secret"] == "1234"
-        assert r[0]["type"] == "SecretFound"
+    x = Generic_JWT()
+    res = FakeResponse(text=jwt_html)
+    r = x.carve(http_response=res)
+    assert r
+    assert r[0]["secret"] == "1234"
+    assert r[0]["type"] == "SecretFound"
 
 
 def test_carve_negativeidentify_body():
@@ -335,15 +289,10 @@ def test_carve_negativeidentify_body():
     <html>
     """
 
-    with respx.mock:
-        respx.get("http://negativeidentify.jsf_viewstate.badsecrets.com/").respond(
-            status_code=200,
-            text=identify_html,
-        )
-        res = httpx.get("http://negativeidentify.jsf_viewstate.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        assert r
-        assert r[0]["type"] == "IdentifyOnly"
+    res = FakeResponse(text=identify_html)
+    r = x.carve(http_response=res)
+    assert r
+    assert r[0]["type"] == "IdentifyOnly"
 
 
 def test_carve_negative():
@@ -358,14 +307,9 @@ def test_carve_negative():
     <html>
     """
 
-    with respx.mock:
-        respx.get("http://negative.generic-jwt.badsecrets.com/").respond(
-            status_code=200,
-            text=useless_html,
-        )
-        res = httpx.get("http://negative.generic-jwt.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        assert not r
+    res = FakeResponse(text=useless_html)
+    r = x.carve(http_response=res)
+    assert not r
 
     x = Generic_JWT()
     useless_html = """
@@ -378,15 +322,10 @@ def test_carve_negative():
     <html>
     """
 
-    with respx.mock:
-        respx.get("http://identifyonly.generic-jwt.badsecrets.com/").respond(
-            status_code=200,
-            text=useless_html,
-        )
-        res = httpx.get("http://identifyonly.generic-jwt.badsecrets.com/")
-        r = x.carve(httpx_response=res)
-        assert r
-        assert r[0]["type"] == "IdentifyOnly"
+    res = FakeResponse(text=useless_html)
+    r = x.carve(http_response=res)
+    assert r
+    assert r[0]["type"] == "IdentifyOnly"
 
 
 def test_invalid_carve_args():
@@ -401,15 +340,10 @@ def test_invalid_carve_args():
     """
     cookies = {"random-cookie": "useless_data"}
     x = Generic_JWT()
-    with respx.mock:
-        cookie_headers = [("set-cookie", f"{k}={v}") for k, v in cookies.items()]
-        respx.get("http://invalidcarveargs.generic-jwt.badsecrets.com/").mock(
-            return_value=httpx.Response(200, text=useless_html, headers=cookie_headers)
-        )
-        res = httpx.get("http://invalidcarveargs.generic-jwt.badsecrets.com/")
+    res = FakeResponse(text=useless_html, cookies=cookies)
 
     with pytest.raises(badsecrets.errors.CarveException):
-        x.carve(body=useless_html, cookies=cookies, httpx_response=res)
+        x.carve(body=useless_html, cookies=cookies, http_response=res)
 
     with pytest.raises(badsecrets.errors.CarveException):
         x.carve(body=useless_html, cookies="cookies")
@@ -418,7 +352,7 @@ def test_invalid_carve_args():
         x.carve(body={"dict": "dict"})
 
     with pytest.raises(badsecrets.errors.CarveException):
-        x.carve(httpx_response=("AAAA"))
+        x.carve(http_response=("AAAA"))
 
     with pytest.raises(badsecrets.errors.CarveException):
         x.carve()

--- a/tests/cli_active_test.py
+++ b/tests/cli_active_test.py
@@ -2,8 +2,6 @@ import os
 import sys
 import tempfile
 import pytest
-import respx
-import httpx
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(f"{os.path.dirname(SCRIPT_DIR)}/examples")
@@ -137,10 +135,9 @@ def test_custom_secrets_passive_module():
 # --- CLI integration tests ---
 
 
-@respx.mock
-def test_passive_only_skips_active(monkeypatch, capsys):
+def test_passive_only_skips_active(monkeypatch, capsys, bh_mock):
     """--passive-only suppresses active probes."""
-    respx.get("https://vpn.example.com").mock(return_value=httpx.Response(200, text=GLOBALPROTECT_PORTAL_HTML))
+    bh_mock.add_response(url="https://vpn.example.com", text=GLOBALPROTECT_PORTAL_HTML, status_code=200)
 
     monkeypatch.setattr(
         "sys.argv",
@@ -153,11 +150,10 @@ def test_passive_only_skips_active(monkeypatch, capsys):
     assert "Active probes are enabled" not in captured.out
 
 
-@respx.mock
-def test_url_mode_runs_active_by_default(monkeypatch, capsys):
+def test_url_mode_runs_active_by_default(monkeypatch, capsys, bh_mock):
     """--url without --passive-only runs active probes (shows active message)."""
-    respx.get("https://vpn.example.com").mock(return_value=httpx.Response(200, text=GLOBALPROTECT_PORTAL_HTML))
-    respx.post("https://vpn.example.com/sslmgr").mock(return_value=httpx.Response(200, text="Invalid Cookie"))
+    bh_mock.add_response(url="https://vpn.example.com", text=GLOBALPROTECT_PORTAL_HTML, status_code=200)
+    bh_mock.add_response(url="https://vpn.example.com/sslmgr", method="POST", text="Invalid Cookie", status_code=200)
 
     monkeypatch.setattr(
         "sys.argv",
@@ -169,12 +165,14 @@ def test_url_mode_runs_active_by_default(monkeypatch, capsys):
     assert "Active probes are enabled" in captured.out
 
 
-@respx.mock
-def test_url_mode_active_finds_secret(monkeypatch, capsys):
+def test_url_mode_active_finds_secret(monkeypatch, capsys, bh_mock):
     """Active probe finds default key and reports it."""
-    respx.get("https://vpn.example.com").mock(return_value=httpx.Response(200, text=GLOBALPROTECT_PORTAL_HTML))
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
+    bh_mock.add_response(url="https://vpn.example.com", text=GLOBALPROTECT_PORTAL_HTML, status_code=200)
+    bh_mock.add_response(
+        url="https://vpn.example.com/sslmgr",
+        method="POST",
+        text="Unable to find the configuration",
+        status_code=200,
     )
 
     monkeypatch.setattr(
@@ -188,12 +186,14 @@ def test_url_mode_active_finds_secret(monkeypatch, capsys):
     assert "p1a2l3o4a5l6t7o8" in captured.out
 
 
-@respx.mock
-def test_url_mode_active_json(monkeypatch, capsys):
+def test_url_mode_active_json(monkeypatch, capsys, bh_mock):
     """Active probe result in JSON mode."""
-    respx.get("https://vpn.example.com").mock(return_value=httpx.Response(200, text=GLOBALPROTECT_PORTAL_HTML))
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
+    bh_mock.add_response(url="https://vpn.example.com", text=GLOBALPROTECT_PORTAL_HTML, status_code=200)
+    bh_mock.add_response(
+        url="https://vpn.example.com/sslmgr",
+        method="POST",
+        text="Unable to find the configuration",
+        status_code=200,
     )
 
     monkeypatch.setattr(
@@ -209,12 +209,14 @@ def test_url_mode_active_json(monkeypatch, capsys):
     assert "p1a2l3o4a5l6t7o8" in captured.out
 
 
-@respx.mock
-def test_url_mode_custom_secrets_for_active(monkeypatch, capsys):
+def test_url_mode_custom_secrets_for_active(monkeypatch, capsys, bh_mock):
     """--custom-secrets MODULE:keys works in URL mode for active modules."""
-    respx.get("https://vpn.example.com").mock(return_value=httpx.Response(200, text=GLOBALPROTECT_PORTAL_HTML))
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
+    bh_mock.add_response(url="https://vpn.example.com", text=GLOBALPROTECT_PORTAL_HTML, status_code=200)
+    bh_mock.add_response(
+        url="https://vpn.example.com/sslmgr",
+        method="POST",
+        text="Unable to find the configuration",
+        status_code=200,
     )
 
     monkeypatch.setattr(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures.
+
+`bh_mock` returns a fresh BlasthttpMock per test. For tests that drive a CLI
+script which constructs its own BlastHTTP client internally, the fixture also
+patches `BlastHTTP` on each example module so the script picks up the mock
+transparently — tests just register responses on `bh_mock` and call the script.
+"""
+
+from unittest.mock import patch
+import pytest
+from blasthttp.mock import BlasthttpMock
+
+from badsecrets.examples import cli, blacklist3r, symfony_knownkey, telerik_knownkey
+
+
+@pytest.fixture
+def bh_mock():
+    """A fresh BlasthttpMock per test, with all CLI script BlastHTTP imports
+    patched to return this mock. Tests register responses with
+    ``bh_mock.add_response(...)`` / ``bh_mock.add_callback(...)``.
+    For library-level tests (active modules), pass it directly via
+    ``http_client=bh_mock`` instead — the patches are harmless either way.
+    """
+    mock = BlasthttpMock()
+    with (
+        patch.object(cli, "BlastHTTP", return_value=mock),
+        patch.object(blacklist3r, "BlastHTTP", return_value=mock),
+        patch.object(symfony_knownkey, "BlastHTTP", return_value=mock),
+        patch.object(telerik_knownkey, "_HTTP_CLIENT", mock),
+    ):
+        yield mock

--- a/tests/examples_blacklist3r_test.py
+++ b/tests/examples_blacklist3r_test.py
@@ -1,7 +1,5 @@
 import os
 import sys
-import httpx
-import respx
 from unittest.mock import patch
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -132,7 +130,7 @@ def test_examples_blacklist3r_manual(monkeypatch, capsys):
         assert "Viewstate is not formatted correctly" in captured.err
 
 
-def test_examples_blacklist3r_offline(monkeypatch, capsys):
+def test_examples_blacklist3r_offline(monkeypatch, capsys, bh_mock):
     with patch("sys.exit") as exit_mock:
         # Invalid URL is rejected
         monkeypatch.setattr("sys.argv", ["python", "--url", "hxxp://notaurl"])
@@ -158,45 +156,48 @@ def test_examples_blacklist3r_offline(monkeypatch, capsys):
         captured = capsys.readouterr()
         assert "error: --viewstate/--generator options and --url option are mutually exclusive" in captured.err
 
-    with respx.mock:
-        respx.get("http://example.com/vulnerableviewstate.aspx").respond(
-            status_code=200,
-            text=base_viewstate_page.replace("###viewstate###", vulnerable_viewstate),
-        )
-        respx.get("http://example.com/nonvulnerableviewstate.aspx").respond(
-            status_code=200,
-            text=base_viewstate_page.replace("###viewstate###", non_vulnerable_viewstate),
-        )
-        respx.get("http://example.com/noviewstate.aspx").respond(status_code=200, text=no_viewstate_page)
-        respx.get("http://notreal.com/").mock(side_effect=httpx.ConnectTimeout("timeout"))
-        # URL Mode - Valid URL is visited, contains viewstate, viewstate is vulnerable
+    bh_mock.add_response(
+        url="http://example.com/vulnerableviewstate.aspx",
+        text=base_viewstate_page.replace("###viewstate###", vulnerable_viewstate),
+        status_code=200,
+    )
+    bh_mock.add_response(
+        url="http://example.com/nonvulnerableviewstate.aspx",
+        text=base_viewstate_page.replace("###viewstate###", non_vulnerable_viewstate),
+        status_code=200,
+    )
+    bh_mock.add_response(url="http://example.com/noviewstate.aspx", text=no_viewstate_page, status_code=200)
 
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerableviewstate.aspx"])
-        blacklist3r.main()
+    def _err(req):
+        raise RuntimeError("timeout")
 
-        # URL Mode - Valid URL is visited, contains viewstate, viewstate is vulnerable
-        captured = capsys.readouterr()
-        assert "Matching MachineKeys found!" in captured.out
-        assert (
-            "F4F0AC3A8889DFBB6FC9D24275A8F0E523C1FB1A2F3FA0C3F3B36320A80670E1D62D15A16A335F0CB14F8AECE7002A5BD8A980F677EA82666B49167947F0A669"
-            in captured.out
-        )
-        assert "encryptionAlgo: AES" in captured.out
+    bh_mock.add_callback(_err, url="http://notreal.com/")
 
-        # URL Mode - Valid URL is visited, contains viewstate, viewstate is NOT vulnerable
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/nonvulnerableviewstate.aspx"])
-        blacklist3r.main()
-        captured2 = capsys.readouterr()
-        assert "Matching MachineKeys NOT found" in captured2.out
+    # URL Mode - Valid URL is visited, contains viewstate, viewstate is vulnerable
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerableviewstate.aspx"])
+    blacklist3r.main()
+    captured = capsys.readouterr()
+    assert "Matching MachineKeys found!" in captured.out
+    assert (
+        "F4F0AC3A8889DFBB6FC9D24275A8F0E523C1FB1A2F3FA0C3F3B36320A80670E1D62D15A16A335F0CB14F8AECE7002A5BD8A980F677EA82666B49167947F0A669"
+        in captured.out
+    )
+    assert "encryptionAlgo: AES" in captured.out
 
-        # URL Mode - Valid URL is visited, does not contain viewstate
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/noviewstate.aspx"])
-        blacklist3r.main()
-        captured2 = capsys.readouterr()
-        assert "Did not find viewstate in repsonse from URL" in captured2.out
+    # URL Mode - Valid URL is visited, contains viewstate, viewstate is NOT vulnerable
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/nonvulnerableviewstate.aspx"])
+    blacklist3r.main()
+    captured2 = capsys.readouterr()
+    assert "Matching MachineKeys NOT found" in captured2.out
 
-        # URL Mode - Validly formatted URL is not responding
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://notreal.com"])
-        blacklist3r.main()
-        captured2 = capsys.readouterr()
-        assert "Error connecting to URL" in captured2.out
+    # URL Mode - Valid URL is visited, does not contain viewstate
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/noviewstate.aspx"])
+    blacklist3r.main()
+    captured2 = capsys.readouterr()
+    assert "Did not find viewstate in repsonse from URL" in captured2.out
+
+    # URL Mode - Validly formatted URL is not responding
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://notreal.com"])
+    blacklist3r.main()
+    captured2 = capsys.readouterr()
+    assert "Error connecting to URL" in captured2.out

--- a/tests/examples_cli_test.py
+++ b/tests/examples_cli_test.py
@@ -2,7 +2,6 @@ import os
 import sys
 import tempfile
 import pytest
-import respx
 from unittest.mock import patch
 from importlib.metadata import PackageNotFoundError
 
@@ -122,141 +121,141 @@ def test_examples_cli_url_both_set(monkeypatch, capsys):
         assert "In --url mode, no positional arguments should be used" in captured.out
 
 
-def test_example_cli_vulnerable_url(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/vulnerablejwt.html").respond(
-            status_code=200,
-            text=base_vulnerable_page,
-        )
+def test_example_cli_vulnerable_url(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/vulnerablejwt.html",
+        text=base_vulnerable_page,
+        status_code=200,
+    )
 
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerablejwt.html"])
-        cli.main()
-        captured = capsys.readouterr()
-        assert "your-256-bit-secret" in captured.out
-
-
-def test_example_cli_vulnerable_headers(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/vulnerableexpress_cs.html").respond(
-            status_code=200,
-            text="<html><body>content</body></html>",
-            headers={
-                "X-Powered-By": "Express",
-                "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": "11",
-                "ETag": 'W/"b-LTx1jc/VQrBurpG4w6qnFsu3lHk"',
-                "Set-Cookie": "session=eyJ1c2VybmFtZSI6IkJib3RJc0xpZmUifQ==; path=/; expires=Sun, 16 Jul 2023 19:56:30 GMT; httponly, session.sig=8BrG9wzvqxuPCtKmfgdyXXGGqA8; path=/; expires=Sun, 16 Jul 2023 19:56:30 GMT; httponly",
-                "Date": "Sat, 15 Jul 2023 02:47:13 GMT",
-                "Connection": "close",
-            },
-        )
-
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerableexpress_cs.html"])
-        cli.main()
-        captured = capsys.readouterr()
-        assert (
-            "Product: Data Cookie: [session=eyJ1c2VybmFtZSI6IkJib3RJc0xpZmUifQ==] Signature Cookie: [8BrG9wzvqxuPCtKmfgdyXXGGqA8]"
-            in captured.out
-        )
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerablejwt.html"])
+    cli.main()
+    captured = capsys.readouterr()
+    assert "your-256-bit-secret" in captured.out
 
 
-def test_example_cli_vulnerable_headersidentifyonly(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/vulnerableexpress_cs.html").respond(
-            status_code=200,
-            text="<html><body>content</body></html>",
-            headers={
-                "X-Powered-By": "Express",
-                "Content-Type": "text/html; charset=utf-8",
-                "Content-Length": "11",
-                "ETag": 'W/"b-LTx1jc/VQrBurpG4w6qnFsu3lHk"',
-                "Set-Cookie": "session=eyJ1c2VybmFtZSI6IkJib3RJc0xpZmUifQ==; path=/; expires=Sun, 16 Jul 2023 19:56:30 GMT; httponly, session.sig=8BrG9wzvqxuPCtKmfgdyXXGGqA7; path=/; expires=Sun, 16 Jul 2023 19:56:30 GMT; httponly",
-                "Date": "Sat, 15 Jul 2023 02:47:13 GMT",
-                "Connection": "close",
-            },
-        )
+def test_example_cli_vulnerable_headers(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/vulnerableexpress_cs.html",
+        text="<html><body>content</body></html>",
+        status_code=200,
+        headers={
+            "X-Powered-By": "Express",
+            "Content-Type": "text/html; charset=utf-8",
+            "Content-Length": "11",
+            "ETag": 'W/"b-LTx1jc/VQrBurpG4w6qnFsu3lHk"',
+            "Set-Cookie": "session=eyJ1c2VybmFtZSI6IkJib3RJc0xpZmUifQ==; path=/; expires=Sun, 16 Jul 2023 19:56:30 GMT; httponly, session.sig=8BrG9wzvqxuPCtKmfgdyXXGGqA8; path=/; expires=Sun, 16 Jul 2023 19:56:30 GMT; httponly",
+            "Date": "Sat, 15 Jul 2023 02:47:13 GMT",
+            "Connection": "close",
+        },
+    )
 
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerableexpress_cs.html"])
-        cli.main()
-        captured = capsys.readouterr()
-        assert (
-            "Data Cookie: [session=eyJ1c2VybmFtZSI6IkJib3RJc0xpZmUifQ==] Signature Cookie: [8BrG9wzvqxuPCtKmfgdyXXGGqA7]"
-            in captured.out
-        )
-        print(captured.out)
-        assert "Cryptographic Product Identified (no vulnerability)" in captured.out
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerableexpress_cs.html"])
+    cli.main()
+    captured = capsys.readouterr()
+    assert (
+        "Product: Data Cookie: [session=eyJ1c2VybmFtZSI6IkJib3RJc0xpZmUifQ==] Signature Cookie: [8BrG9wzvqxuPCtKmfgdyXXGGqA8]"
+        in captured.out
+    )
 
 
-def test_example_cli_not_vulnerable_url(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/notvulnerable.html").respond(
-            status_code=200,
-            text=base_non_vulnerable_page,
-        )
+def test_example_cli_vulnerable_headersidentifyonly(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/vulnerableexpress_cs.html",
+        text="<html><body>content</body></html>",
+        status_code=200,
+        headers={
+            "X-Powered-By": "Express",
+            "Content-Type": "text/html; charset=utf-8",
+            "Content-Length": "11",
+            "ETag": 'W/"b-LTx1jc/VQrBurpG4w6qnFsu3lHk"',
+            "Set-Cookie": "session=eyJ1c2VybmFtZSI6IkJib3RJc0xpZmUifQ==; path=/; expires=Sun, 16 Jul 2023 19:56:30 GMT; httponly, session.sig=8BrG9wzvqxuPCtKmfgdyXXGGqA7; path=/; expires=Sun, 16 Jul 2023 19:56:30 GMT; httponly",
+            "Date": "Sat, 15 Jul 2023 02:47:13 GMT",
+            "Connection": "close",
+        },
+    )
 
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/notvulnerable.html"])
-        cli.main()
-        captured = capsys.readouterr()
-        assert "No secrets found :(" in captured.out
-
-
-def test_example_cli_identifyonly_url(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/identifyonly.html").respond(
-            status_code=200,
-            text=base_identifyonly_page,
-        )
-
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/identifyonly.html"])
-        cli.main()
-        captured = capsys.readouterr()
-        print(captured)
-        assert "Cryptographic Product Identified (no vulnerability)" in captured.out
-
-
-def test_example_cli_identifyonly_hashcat(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/identifyonly.html").respond(
-            status_code=200,
-            text=base_identifyonly_page,
-        )
-
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.ovqRikAo_0kKJ0GVrAwQlezymxrLGjcEiW_s3UJMMCB",
-            ],
-        )
-        cli.main()
-        captured = capsys.readouterr()
-        print(captured)
-        assert "No secrets found :(" in captured.out
-        assert "Potential matching hashcat commands:" in captured.out
-        assert "JSON Web Token (JWT) Algorithm: HS256 Command: [hashcat -m 16500" in captured.out
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerableexpress_cs.html"])
+    cli.main()
+    captured = capsys.readouterr()
+    assert (
+        "Data Cookie: [session=eyJ1c2VybmFtZSI6IkJib3RJc0xpZmUifQ==] Signature Cookie: [8BrG9wzvqxuPCtKmfgdyXXGGqA7]"
+        in captured.out
+    )
+    print(captured.out)
+    assert "Cryptographic Product Identified (no vulnerability)" in captured.out
 
 
-def test_example_cli_identifyonly_hashcat_rack2(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/identifyonly.html").respond(
-            status_code=200,
-            text=base_identifyonly_page,
-        )
+def test_example_cli_not_vulnerable_url(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/notvulnerable.html",
+        text=base_non_vulnerable_page,
+        status_code=200,
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "BAh7B0kiD3Nlc3Npb25faWQGOgZFVG86HVJhY2s6OlNlc3Npb246OlNlc3Npb25JZAY6D0BwdWJsaWNfaWRJIkU5YmI3ZDUyODUyNTAwMDYzMGE2NjMxYTA5MjBlMjYzMzFmOGE0MjBhNTdhYWIxNzVkZTFmM2FjMDQ3NmI1NDQzBjsARkkiCmNvdW50BjsARmkG--2a983fbc58911c5266d7748a6a55165f74d412f4",
-            ],  # intentionally bad signature to test hashcat function
-        )
-        cli.main()
-        captured = capsys.readouterr()
-        print(captured)
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/notvulnerable.html"])
+    cli.main()
+    captured = capsys.readouterr()
+    assert "No secrets found :(" in captured.out
 
-        assert "No secrets found :(" in captured.out
-        assert "[Rack2_SignedCookies] Rack 2.x Signed Cookie" in captured.out
-        assert "Potential matching hashcat commands" in captured.out
+
+def test_example_cli_identifyonly_url(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/identifyonly.html",
+        text=base_identifyonly_page,
+        status_code=200,
+    )
+
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/identifyonly.html"])
+    cli.main()
+    captured = capsys.readouterr()
+    print(captured)
+    assert "Cryptographic Product Identified (no vulnerability)" in captured.out
+
+
+def test_example_cli_identifyonly_hashcat(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/identifyonly.html",
+        text=base_identifyonly_page,
+        status_code=200,
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkJhZFNlY3JldHMiLCJleHAiOjE1OTMxMzM0ODMsImlhdCI6MTQ2NjkwMzA4M30.ovqRikAo_0kKJ0GVrAwQlezymxrLGjcEiW_s3UJMMCB",
+        ],
+    )
+    cli.main()
+    captured = capsys.readouterr()
+    print(captured)
+    assert "No secrets found :(" in captured.out
+    assert "Potential matching hashcat commands:" in captured.out
+    assert "JSON Web Token (JWT) Algorithm: HS256 Command: [hashcat -m 16500" in captured.out
+
+
+def test_example_cli_identifyonly_hashcat_rack2(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/identifyonly.html",
+        text=base_identifyonly_page,
+        status_code=200,
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "BAh7B0kiD3Nlc3Npb25faWQGOgZFVG86HVJhY2s6OlNlc3Npb246OlNlc3Npb25JZAY6D0BwdWJsaWNfaWRJIkU5YmI3ZDUyODUyNTAwMDYzMGE2NjMxYTA5MjBlMjYzMzFmOGE0MjBhNTdhYWIxNzVkZTFmM2FjMDQ3NmI1NDQzBjsARkkiCmNvdW50BjsARmkG--2a983fbc58911c5266d7748a6a55165f74d412f4",
+        ],  # intentionally bad signature to test hashcat function
+    )
+    cli.main()
+    captured = capsys.readouterr()
+    print(captured)
+
+    assert "No secrets found :(" in captured.out
+    assert "[Rack2_SignedCookies] Rack 2.x Signed Cookie" in captured.out
+    assert "Potential matching hashcat commands" in captured.out
 
 
 def test_example_cli_hashcat_omittedonmatch(monkeypatch, capsys):
@@ -523,7 +522,7 @@ def test_example_cli_customsecrets_toolarge(monkeypatch, capsys):
         assert "exceeds the maximum limit of 100KB!" in captured.out
 
 
-def test_example_cli_customsecrets_urlmode_expressbase64(monkeypatch, capsys):
+def test_example_cli_customsecrets_urlmode_expressbase64(monkeypatch, capsys, bh_mock):
     base_vulnerable_page_jsf_custom = """
 <p><input type="hidden" name="javax.faces.ViewState" id="j_id__v_0:javax.faces.ViewState:1" value="AHo0wmLu5ceItIi+I7XkEi1GAb4h12WZ894pA+Z4OH7bco2jXEy1RSCWwjtJcZNbWPcvPqL5zzfl03DoeMZfGGX7a9PSv+fUT8MAeKNouAGj1dZuO8srXt8xZIGg+wPCWWCzcX6IhWOtgWUwiXeSojCDTKXklsYt+kzlVBk5wOsXvb2lTJoO0Q==" autocomplete="off" />
 """
@@ -532,32 +531,32 @@ def test_example_cli_customsecrets_urlmode_expressbase64(monkeypatch, capsys):
         f.write("base64:aGFja3RoZXBsYW5ldA==")
         f.flush()
 
-        with respx.mock:
-            respx.get("http://example.com/vulnerablejsf.html").respond(
-                status_code=200,
-                text=base_vulnerable_page_jsf_custom,
-            )
+        bh_mock.add_response(
+            url="http://example.com/vulnerablejsf.html",
+            text=base_vulnerable_page_jsf_custom,
+            status_code=200,
+        )
 
-            monkeypatch.setattr(
-                "sys.argv",
-                [
-                    "python",
-                    "--url",
-                    "http://example.com/vulnerablejsf.html",
-                    "-c",
-                    f.name,
-                ],
-            )
-            cli.main()
-            captured = capsys.readouterr()
-            print(captured)
-            assert ("Including custom secrets list") in captured.out
-            assert (
-                "e496c62dfa4ce5541939c0eb17bdbda54c9a0ed1:007a34c262eee5c788b488be23b5e4122d4601be21d76599f3de2903e678387edb728da35c4cb5452096c23b4971935b58f72f3ea2f9cf37e5d370e878c65f1865fb6bd3d2bfe7d44fc30078a368b801a3d5d66e3bcb2b5edf316481a0fb03c25960b3717e888563ad816530897792a230834ca5"
-            ) in captured.out
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "python",
+                "--url",
+                "http://example.com/vulnerablejsf.html",
+                "-c",
+                f.name,
+            ],
+        )
+        cli.main()
+        captured = capsys.readouterr()
+        print(captured)
+        assert ("Including custom secrets list") in captured.out
+        assert (
+            "e496c62dfa4ce5541939c0eb17bdbda54c9a0ed1:007a34c262eee5c788b488be23b5e4122d4601be21d76599f3de2903e678387edb728da35c4cb5452096c23b4971935b58f72f3ea2f9cf37e5d370e878c65f1865fb6bd3d2bfe7d44fc30078a368b801a3d5d66e3bcb2b5edf316481a0fb03c25960b3717e888563ad816530897792a230834ca5"
+        ) in captured.out
 
 
-def test_example_cli_customsecrets_urlmode(monkeypatch, capsys):
+def test_example_cli_customsecrets_urlmode(monkeypatch, capsys, bh_mock):
     base_vulnerable_page_aspnet_custom = """
     <form method="post" action="./form.aspx" id="ctl00">
 <div class="aspNetHidden">
@@ -597,25 +596,25 @@ function __doPostBack(eventTarget, eventArgument) {
         )
         f.flush()
 
-        with respx.mock:
-            respx.get("http://example.com/vulnerableaspnet.html").respond(
-                status_code=200,
-                text=base_vulnerable_page_aspnet_custom,
-            )
+        bh_mock.add_response(
+            url="http://example.com/vulnerableaspnet.html",
+            text=base_vulnerable_page_aspnet_custom,
+            status_code=200,
+        )
 
-            monkeypatch.setattr(
-                "sys.argv",
-                [
-                    "python",
-                    "--url",
-                    "http://example.com/vulnerableaspnet.html",
-                    "-c",
-                    f.name,
-                ],
-            )
-            cli.main()
-            captured = capsys.readouterr()
-            assert ("Known Secret Found!") in captured.out
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "python",
+                "--url",
+                "http://example.com/vulnerableaspnet.html",
+                "-c",
+                f.name,
+            ],
+        )
+        cli.main()
+        captured = capsys.readouterr()
+        assert ("Known Secret Found!") in captured.out
 
 
 def test_example_cli_color(monkeypatch, capsys):
@@ -646,7 +645,7 @@ def test_example_cli_help(monkeypatch, capsys):
         assert "--user-agent USER_AGENT" in captured.out
 
 
-def test_example_cli_dotnet45_url(monkeypatch, capsys):
+def test_example_cli_dotnet45_url(monkeypatch, capsys, bh_mock):
     base_vulnerable_page_aspnet_dotnet45 = """
          <form method="post" action="./form.aspx" id="ctl00">
 <div class="aspNetHidden">
@@ -679,27 +678,27 @@ function __doPostBack(eventTarget, eventArgument) {
     <input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="1E02dhhNh5Elng+wXjTw6opqE8R/OdZddtcAL82qdZyIIRVQ8s97YQsJqECjV/OJQAu5ZySO9StoIr1X0S6NUbt/h4tCjnSvkgol4hnPb0DshxRmrMTYr/s+zlBn09dZFQ40HKbQeaRIxkww99sDGqnXdTyIOjVxrVW2FmKJSm8=" />
 </div>
     """
-    with respx.mock:
-        respx.get("http://172.16.25.128/form.aspx").respond(
-            status_code=200,
-            text=base_vulnerable_page_aspnet_dotnet45,
-        )
+    bh_mock.add_response(
+        url="http://172.16.25.128/form.aspx",
+        text=base_vulnerable_page_aspnet_dotnet45,
+        status_code=200,
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://172.16.25.128/form.aspx",
-            ],
-        )
-        cli.main()
-        captured = capsys.readouterr()
-        assert ("Known Secret Found!") in captured.out
-        assert ("Details: Mode [DOTNET45]") in captured.out
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://172.16.25.128/form.aspx",
+        ],
+    )
+    cli.main()
+    captured = capsys.readouterr()
+    assert ("Known Secret Found!") in captured.out
+    assert ("Details: Mode [DOTNET45]") in captured.out
 
 
-def test_example_cli_aspnetcompressedviewstate_url(monkeypatch, capsys):
+def test_example_cli_aspnetcompressedviewstate_url(monkeypatch, capsys, bh_mock):
     base_vulnerable_page_aspnet_compressedviewstate = """
          <!doctype html>
 
@@ -725,28 +724,28 @@ def test_example_cli_aspnetcompressedviewstate_url(monkeypatch, capsys):
 <p>content</p>
 </html>
     """
-    with respx.mock:
-        respx.get("http://172.16.25.128/form.aspx").respond(
-            status_code=200,
-            text=base_vulnerable_page_aspnet_compressedviewstate,
-        )
+    bh_mock.add_response(
+        url="http://172.16.25.128/form.aspx",
+        text=base_vulnerable_page_aspnet_compressedviewstate,
+        status_code=200,
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://172.16.25.128/form.aspx",
-            ],
-        )
-        cli.main()
-        captured = capsys.readouterr()
-        assert ("Known Secret Found!") in captured.out
-        assert ("Product: H4sIAAAAAAAEAPvPyJ/Cz8ppZGpgaWpgZmmYAgAAmCJNEQAAAA==") in captured.out
-        assert ("ASP.NET Compressed Viewstate") in captured.out
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://172.16.25.128/form.aspx",
+        ],
+    )
+    cli.main()
+    captured = capsys.readouterr()
+    assert ("Known Secret Found!") in captured.out
+    assert ("Product: H4sIAAAAAAAEAPvPyJ/Cz8ppZGpgaWpgZmmYAgAAmCJNEQAAAA==") in captured.out
+    assert ("ASP.NET Compressed Viewstate") in captured.out
 
 
-def test_example_cli_aspnetcompressedviewstate_url_alternateparamname(monkeypatch, capsys):
+def test_example_cli_aspnetcompressedviewstate_url_alternateparamname(monkeypatch, capsys, bh_mock):
     base_vulnerable_page_aspnet_compressedviewstate = """
          <!doctype html>
 
@@ -769,25 +768,25 @@ def test_example_cli_aspnetcompressedviewstate_url_alternateparamname(monkeypatc
 <p>content</p>
 </html>
     """
-    with respx.mock:
-        respx.get("http://172.16.25.128/form.aspx").respond(
-            status_code=200,
-            text=base_vulnerable_page_aspnet_compressedviewstate,
-        )
+    bh_mock.add_response(
+        url="http://172.16.25.128/form.aspx",
+        text=base_vulnerable_page_aspnet_compressedviewstate,
+        status_code=200,
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://172.16.25.128/form.aspx",
-            ],
-        )
-        cli.main()
-        captured = capsys.readouterr()
-        assert ("Known Secret Found!") in captured.out
-        assert ("Product: H4sIAAAAAAAEAPvPyJ/Cz8ppZGpgaWpgZmmYAgAAmCJNEQAAAA==") in captured.out
-        assert ("ASP.NET Compressed Viewstate") in captured.out
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://172.16.25.128/form.aspx",
+        ],
+    )
+    cli.main()
+    captured = capsys.readouterr()
+    assert ("Known Secret Found!") in captured.out
+    assert ("Product: H4sIAAAAAAAEAPvPyJ/Cz8ppZGpgaWpgZmmYAgAAmCJNEQAAAA==") in captured.out
+    assert ("ASP.NET Compressed Viewstate") in captured.out
 
 
 def test_example_cli_dotnet45_manual(monkeypatch, capsys):
@@ -870,101 +869,106 @@ def test_examples_cli_colors_info(monkeypatch, capsys):
     print(captured.out)
 
 
-def test_example_cli_redirects_followed(monkeypatch, capsys):
+def test_example_cli_redirects_followed(monkeypatch, capsys, bh_mock):
     """Redirects are always followed — secret on the final page is found."""
-    with respx.mock:
-        respx.get("http://example.com/vulnerablejwt.html").respond(
-            status_code=200,
-            text=base_vulnerable_page,
-        )
+    bh_mock.add_response(
+        url="http://example.com/vulnerablejwt.html",
+        text=base_vulnerable_page,
+        status_code=200,
+    )
 
-        respx.get("http://example.com/vulnerablejwt-redir.html").respond(
-            status_code=302, headers={"Location": "vulnerablejwt.html"}
-        )
+    bh_mock.add_response(
+        url="http://example.com/vulnerablejwt-redir.html",
+        status_code=302,
+        headers={"Location": "http://example.com/vulnerablejwt.html"},
+    )
 
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerablejwt-redir.html"])
-        cli.main()
-        captured = capsys.readouterr()
-        assert "your-256-bit-secret" in captured.out
-
-
-def test_example_cli_redirects_default(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/vulnerablejwt.html").respond(
-            status_code=200,
-        )
-
-        respx.get("http://example.com/vulnerablejwt-redir.html").respond(
-            status_code=302,
-            text=base_vulnerable_page,
-            headers={"Location": "vulnerablejwt.html"},
-        )
-
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerablejwt-redir.html"])
-        cli.main()
-        captured = capsys.readouterr()
-        assert "your-256-bit-secret" in captured.out
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerablejwt-redir.html"])
+    cli.main()
+    captured = capsys.readouterr()
+    assert "your-256-bit-secret" in captured.out
 
 
-def test_example_cli_trailing_slash_redirect(monkeypatch, capsys):
+def test_example_cli_redirects_default(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/vulnerablejwt.html",
+        status_code=200,
+    )
+
+    bh_mock.add_response(
+        url="http://example.com/vulnerablejwt-redir.html",
+        status_code=302,
+        text=base_vulnerable_page,
+        headers={"Location": "http://example.com/vulnerablejwt.html"},
+    )
+
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerablejwt-redir.html"])
+    cli.main()
+    captured = capsys.readouterr()
+    assert "your-256-bit-secret" in captured.out
+
+
+def test_example_cli_trailing_slash_redirect(monkeypatch, capsys, bh_mock):
     """Trailing-slash redirect (e.g. /path -> /path/) — secret on followed page is found."""
-    with respx.mock:
-        respx.get("http://example.com/vulnerablejwt").respond(
-            status_code=301,
-            headers={"Location": "http://example.com/vulnerablejwt/"},
-        )
+    bh_mock.add_response(
+        url="http://example.com/vulnerablejwt",
+        status_code=301,
+        headers={"Location": "http://example.com/vulnerablejwt/"},
+    )
 
-        respx.get("http://example.com/vulnerablejwt/").respond(
-            status_code=200,
-            text=base_vulnerable_page,
-        )
+    bh_mock.add_response(
+        url="http://example.com/vulnerablejwt/",
+        text=base_vulnerable_page,
+        status_code=200,
+    )
 
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerablejwt"])
-        cli.main()
-        captured = capsys.readouterr()
-        assert "your-256-bit-secret" in captured.out
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/vulnerablejwt"])
+    cli.main()
+    captured = capsys.readouterr()
+    assert "your-256-bit-secret" in captured.out
 
 
-def test_example_cli_redirect_secret_in_initial_response(monkeypatch, capsys):
+def test_example_cli_redirect_secret_in_initial_response(monkeypatch, capsys, bh_mock):
     """Secret in the redirect response body is found even though we also follow.
     Both the initial response and the redirect target are evaluated.
     """
-    with respx.mock:
-        respx.get("http://example.com/old-page").respond(
-            status_code=301,
-            text=base_vulnerable_page,
-            headers={"Location": "http://example.com/new-page/"},
-        )
-        respx.get("http://example.com/new-page/").respond(
-            status_code=200,
-            text=base_non_vulnerable_page,
-        )
+    bh_mock.add_response(
+        url="http://example.com/old-page",
+        status_code=301,
+        text=base_vulnerable_page,
+        headers={"Location": "http://example.com/new-page/"},
+    )
+    bh_mock.add_response(
+        url="http://example.com/new-page/",
+        text=base_non_vulnerable_page,
+        status_code=200,
+    )
 
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/old-page"])
-        cli.main()
-        captured = capsys.readouterr()
-        # Should detect from the redirect response body itself
-        assert "your-256-bit-secret" in captured.out
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/old-page"])
+    cli.main()
+    captured = capsys.readouterr()
+    # Should detect from the redirect response body itself
+    assert "your-256-bit-secret" in captured.out
 
 
 serverside_jsfviewstate_html = '<input type="hidden" name="javax.faces.ViewState" id="javax.faces.ViewState" value="-7521159484971427124:9144573339387850859" autocomplete="off" /></form>'
 
 
 # We don't actually care at all about this if it has the server-side viewstate - its completely useless
-def test_example_cli_jsfviewstate_serverside(monkeypatch, capsys):
-    with respx.mock:
-        respx.get("http://example.com/serverside_jsfviewstate.html").respond(
-            status_code=200,
-            text=serverside_jsfviewstate_html,
-        )
+def test_example_cli_jsfviewstate_serverside(monkeypatch, capsys, bh_mock):
+    bh_mock.add_response(
+        url="http://example.com/serverside_jsfviewstate.html",
+        text=serverside_jsfviewstate_html,
+        status_code=200,
+    )
 
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/serverside_jsfviewstate.html"])
-        cli.main()
-        captured = capsys.readouterr()
-        assert (
-            "Cryptographic Product Identified (no vulnerability)" not in captured.out
-        )  # make sure we didn't report it at all
-        assert "Potential matching hashcat commands:" not in captured.out
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://example.com/serverside_jsfviewstate.html"])
+    cli.main()
+    captured = capsys.readouterr()
+    assert (
+        "Cryptographic Product Identified (no vulnerability)" not in captured.out
+    )  # make sure we didn't report it at all
+    assert "Potential matching hashcat commands:" not in captured.out
 
 
 def test_example_cli_no_args(monkeypatch, capsys):

--- a/tests/examples_symfony_signedurl_test.py
+++ b/tests/examples_symfony_signedurl_test.py
@@ -1,7 +1,7 @@
 import os
 import sys
-import httpx
-import respx
+import re
+from blasthttp.mock import MockResponse
 from unittest.mock import patch
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -13,20 +13,22 @@ from badsecrets import modules_loaded
 Symfony_SignedURL = modules_loaded["symfony_signedurl"]
 
 
-def test_symfony_url_not_up(monkeypatch, capsys):
-    with respx.mock:
-        # URL is down - handled correctly
+def test_symfony_url_not_up(monkeypatch, capsys, bh_mock):
+    """URL is down — handled correctly."""
 
-        respx.get("http://notreal.com/_fragment").mock(side_effect=httpx.ConnectTimeout("timeout"))
-        monkeypatch.setattr("sys.argv", ["python", "--url", "http://notreal.com"])
-        symfony_knownkey.main()
-        captured = capsys.readouterr()
-        assert "Error connecting to URL" in captured.out
+    def _err(req):
+        raise RuntimeError("timeout")
+
+    bh_mock.add_callback(_err, url="http://notreal.com/_fragment")
+
+    monkeypatch.setattr("sys.argv", ["python", "--url", "http://notreal.com"])
+    symfony_knownkey.main()
+    captured = capsys.readouterr()
+    assert "Error connecting to URL" in captured.out
 
 
 def test_symfony_url_malformed(monkeypatch, capsys):
-    # URL is not properly formatted
-
+    """URL is not properly formatted."""
     with patch("sys.exit") as exit_mock:
         monkeypatch.setattr("sys.argv", ["python", "--url", "hxxp://notreal.com"])
         symfony_knownkey.main()
@@ -35,7 +37,7 @@ def test_symfony_url_malformed(monkeypatch, capsys):
         assert "URL is not formatted correctly" in captured.err
 
 
-def test_symfony_brute_success(monkeypatch, capsys, mocker):
+def test_symfony_brute_success(monkeypatch, capsys, bh_mock):
     phpcredits_page = """
     <tr class="h"><th>PHP Group</th></tr>
 <tr><td class="e">Thies C. Arntzen, Stig Bakken, Shane Caraveo, Andi Gutmans, Rasmus Lerdorf, Sam Ruby, Sascha Schumann, Zeev Suraski, Jim Winstead, Andrei Zmievski </td></tr>
@@ -54,26 +56,19 @@ def test_symfony_brute_success(monkeypatch, capsys, mocker):
 <tr><td class="e">Server API (SAPI) Abstraction Layer </td><td class="v">Andi Gutmans, Shane Caraveo, Zeev Suraski </td></tr>
     """
 
-    with respx.mock:
-        respx.get("https://localhost/AAAAAAAA").respond(
-            status_code=404,
-            text="",
-        )
+    bh_mock.add_callback(
+        lambda req: MockResponse(text="", status_code=404),
+        url="https://localhost/AAAAAAAA",
+    )
 
-        # Use a side_effect dispatcher because respx matches URLs without considering
-        # query parameters, so a route for "_fragment" would also match "_fragment?_path=..."
-        def _fragment_dispatcher(request):
-            if "_hash=SrBMT/u6I0ylFIn/i6LYayCog21DnFMJ7yFBSnZpImA=" in str(request.url):
-                return httpx.Response(200, text=phpcredits_page)
-            return httpx.Response(403, text="")
+    def _fragment_dispatcher(request):
+        if "_hash=SrBMT/u6I0ylFIn/i6LYayCog21DnFMJ7yFBSnZpImA=" in request.url:
+            return MockResponse(text=phpcredits_page, status_code=200)
+        return MockResponse(text="", status_code=403)
 
-        respx.get(url__startswith="https://localhost/_fragment").mock(side_effect=_fragment_dispatcher)
+    bh_mock.add_callback(_fragment_dispatcher, url=re.compile(r"^https://localhost/_fragment.*"))
 
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "https://localhost/"],
-        )
-        symfony_knownkey.main()
-        captured = capsys.readouterr()
-        assert "Found Symfony Secret! [50c8215b436ebfcc1d568effb624a40e]" in captured.out
-        print(captured)
+    monkeypatch.setattr("sys.argv", ["python", "--url", "https://localhost/"])
+    symfony_knownkey.main()
+    captured = capsys.readouterr()
+    assert "Found Symfony Secret! [50c8215b436ebfcc1d568effb624a40e]" in captured.out

--- a/tests/examples_telerik_knownkey_test.py
+++ b/tests/examples_telerik_knownkey_test.py
@@ -1,8 +1,8 @@
 import os
 import sys
-import httpx
-import respx
 from unittest.mock import patch
+
+from blasthttp.mock import MockResponse
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(f"{os.path.dirname(SCRIPT_DIR)}/examples")
@@ -15,7 +15,7 @@ Telerik_EncryptionKey = modules_loaded["telerik_encryptionkey"]
 
 
 def _body(request):
-    """Helper to get request body as a string (httpx request.content is bytes)."""
+    """Helper to get request body as a string (MockRequest.content is bytes)."""
     return request.content.decode() if request.content else ""
 
 
@@ -256,35 +256,40 @@ def test_examples_telerik_knownkey_argparsing(monkeypatch, capsys):
         assert "URL is not formatted correctly" in captured.err
 
 
-def test_non_telerik_ui(monkeypatch, capsys):
+def test_non_telerik_ui(monkeypatch, capsys, bh_mock):
     # Non-Telerk UI is detected
-    with respx.mock:
-        respx.get("http://nottelerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text="<html><p>Just a regular website</p></html>"
-        )
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://nottelerik.com/Telerik.Web.UI.DialogHandler.aspx"],
-        )
+    bh_mock.add_response(
+        url="http://nottelerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text="<html><p>Just a regular website</p></html>",
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://nottelerik.com/Telerik.Web.UI.DialogHandler.aspx"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured)
+    assert "URL does not appear to be a Telerik UI DialogHandler" in captured.out
+
+
+def test_url_not_up(monkeypatch, capsys, bh_mock):
+    # URL is down - handled correctly
+    with patch("sys.exit") as exit_mock:
+
+        def _err(req):
+            raise RuntimeError("connection error")
+
+        bh_mock.add_callback(_err, url="http://notreal.com/")
+        monkeypatch.setattr("sys.argv", ["python", "--url", "http://notreal.com"])
         telerik_knownkey.main()
         captured = capsys.readouterr()
-        print(captured)
-        assert "URL does not appear to be a Telerik UI DialogHandler" in captured.out
+        assert "Network error connecting to URL" in captured.out
+        assert exit_mock.called
 
 
-def test_url_not_up(monkeypatch, capsys):
-    with respx.mock:
-        # URL is down - handled correctly
-        with patch("sys.exit") as exit_mock:
-            respx.get("http://notreal.com/").mock(side_effect=httpx.ConnectTimeout("error"))
-            monkeypatch.setattr("sys.argv", ["python", "--url", "http://notreal.com"])
-            telerik_knownkey.main()
-            captured = capsys.readouterr()
-            assert "Network error connecting to URL" in captured.out
-            assert exit_mock.called
-
-
-def test_fullrun_PBKDF2(monkeypatch, capsys, mocker):
+def test_fullrun_PBKDF2(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(
             ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
@@ -296,50 +301,52 @@ def test_fullrun_PBKDF2(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF2_version_probe_matcher_incorrect(request):
-                return httpx.Response(
-                    200,
-                    text="Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF2_version_probe_matcher(request):
-                return httpx.Response(200, text="DoesntMatter")
-            if PBKDF2_found_key_matcher_negative(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
-                )
-            if PBKDF2_found_key_matcher(request):
-                return httpx.Response(
-                    200,
-                    text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF2_version_probe_matcher_incorrect(request):
+            return MockResponse(
+                status_code=200,
+                text="Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF2_version_probe_matcher(request):
+            return MockResponse(status_code=200, text="DoesntMatter")
+        if PBKDF2_found_key_matcher_negative(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
+            )
+        if PBKDF2_found_key_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a newer version of Telerik UI" in captured.out
-        assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert "SUCCESS! Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert ("SUCCESS! Found working version: 2018.1.117") in captured.out
-        assert (
-            "%2Bv%2BRs6kf9lDUYnqqYk32Vg84DkpdruQOKGZRmm6RMkaYuxNmvg5Ca5cT%2F74qkOozHIKkG1ovf6XBsjlp4kgO8BJ6KgNcT78BExQZfT1mN5rMO8kcLDRdffFhFXmvAr0o%2F4x%2B9VoRJVaOyGLXk2nhX4OMP%2BjGP2C96Fa6LyfGWHlk1CF0E5mAPeQ6CLbycR88WU5hlmUUqniXC2UdeYd6HO9RFnISEnhq72MkdiEfvNsqAhr2XaCX2%2BQxFXfCLi2%2Fc%2Bn2NmUiFRdhCLutnVxILEnYiRmU5eHJdB2IOTtoc2XZ3NUdZJwrwOswjzCkk7LOwt2bddTvOXdfWtRrbNz1GDNXlPz1cXotgAhucxLLsknNDbeeboMbL%2Bk3tIeervi7oI%2FRQn6Ml3ffUAfcqHzwcZCEIlQXh%2FBEIKHAY9fGKs5JSdtRbREDI0rh9sH%2B0TmYv444WQyqYpa8pOqtxgC1QRRcsNQcVGFzpyNL2SfKSlLTZi5Q7bo8XMTfLG6jg60csDEDiJ7MwJBGIm1iYzt%2FP9JEKkZujTMyHoBI0RESNpux7BeanEIDsfDmfwbcUo%2B2%2BkoHkCE4zXWBdW3lqssk4GwSbc0mbmf3U79rsQdNEqIOL87evE1U6tGB5PuXgwAIj9sKdyffd8%2B%2Bz1CCffFovLM72ilbCmSljAJ%2BvVBfNpTiL7RV7j3XGygljzi4NL8yXJuCLYiNxmqPMdV8DahLed0jSe2mkU1u6rx4yS3dcWEfwMWjI5tVrfnbqtdInC8TliXkTZ919CtORoydmIXGL1u3kdBIq8EZcjRMa4bN4VTvUlbqeIe8p8QYEQwAi7vXiZCKS6R6dmJfQv%2B%2FqBHXWSFuglLYde019GNtNdGQfEnY31zT0Q86ieDYn4k55LbYq5lK8PNjg50gdJxn9fNtHTQ7frKP9vRM4cImRSvDBTATVw1PDzMqn0exo3xciYd5%2BXYAxlFoqwFMDz40w2xR4OWwoPsixpVjR2DYiqYiZrYytFMjziRCLQhkVuJpED8nB9CTlo05WBKN%2Bb4UBHBg%2FkCkHXJxNakIX7UbAjDcqzrNCGhjrgehCGA81uOf0Ppfswda0ZHMi8g9W6Y7uwWmn7Ux7xBMgDCUNIi8I3UvLGXdKnuB8YHX8TLC1z2%2Fm3ip797Pix1ya2sBsbw9KgOJ7PBT0u9W0puchi7zpT%2FzFe3V2HbV0ottDethRJhzaN856VgvjyNhbbmA04gnal%2Fq01j7LNWxEwTjNPyHORI1l9jztvYqItLei7YQYg2pFhmvuv0Od8DPfH40Y1m3mL2F2d%2FAy3ImzFI%2BKQB6mnGPvRcDIS1j7zPhciKRuLfu3dCxhIH7ojo83rhQus3SyXdyZ5cjkFKcG3H7WmBBMOFs2o5xjWcdLARevRbNbqwRfATerc5GuJxy1Qb8RJvOqhDcS5YAHyxVMx2QYU3yMhg0tCpy4wW%2FHsa33feu3NeBu9lRI38ojJNM7o6xYRoSTQu4tYadB4Yh4w60e%2FsttnecOC5plZrLw6BYN2piqvUD07BnO4yTvrpdBDXR%2BMFDchnFh2YK9JtvvtAISvpoSOJojOhwRKuafCwEJn0GB1dsdmOOxxaFHkPXQ7789eCxlTL5mkVf3ktzmHQdDyBxBlDLFWSjmFIBHp%2BPobFdDOmv5p6J3%2F%2FM23PMgGDLRMrj5LVZV3trGV1ZaJHEFIGmVwW0tN4426Q4rCdcxT4ju%2B%2FNhcq90e8crWw9nrF2rPTzW1YM7VqWWwhLj8MtVtGZFa3N%2FxdjEys8FWyT8VqAbC4IltuT5lW1ou1SXsA96h%2F9y3vzJADbm4Lv624OGnh6M%2FCmR930i6YeUlWWmMw1%2FpcZ5werHPm9v0OWulNmGfbNEoKuThz2sSCZ8FLNVToygv1VXPXnur4dJnoCkwBP2%2BQQ6%2FHlyFRXnrrGsiDJE3qtRXgECIhc2zpuC5HAz9FhIfC9VZZ5nxRMbhA6W%2Fz%2BjPpKLCBpmLqHJfy8%2B%2FausiZJv7d9yQ0SvHtq0y%2FSY04hOgZTJul6IIYpObD6s%2FqrGy2nMmY3%2FtEn830%2F%2BFERnXMeBsj%2B%2F5ZSewYe4xBnub1wvSbsA3qjoU5gq7fhDJOhmMQXkbas%2FRholsU9CNKNXpSyqVarqAc8XwaG34JmdG3wjQXd6p%2Bz2jZLew5ja8nelvVdIeN%2F9ejCNOoXcPApYLHyxslcrEuJrSHlAMR4FbonfrFhYYTR%2B8pdxRGYGpVUDxlIRvayztxVhLnSpRwg5uIXktoMwJ%2FSaF8x29hA9LIyUqAu4%2FR2hQW%2B4SImPpsXXpqtiGkjfub23eHBh6%2BtPfI7KNBt0Sz%2F3IcUvQk%2BWZYFfPMd8cXJdempaxEs%2BWRlN16p%2BjqhLiVh2A8iaZ4WvdHZmEP7slp3BgAJHjnl7C9sEWeDqCEwe%2FjIDLeJ1X%2FDjBXwflC7CNUtfL5Xw3En%2FArqlvVhUGhwvFy6lQocBfs6%2BLYvOaWiwZ37DX8rkRZlWpkY2rpapUrmnba7Ly%2FoLx924DzkK78M%2BzFL0ra5b1t6Rgv5zuibZAhF47t1EdOxpWIlBlf3zB9gg2M5Rk%2F9IMH%2BzrDHou9o9uO%2BDC6WFddIOuEWc1nrjSenwFkvqgNVdc9CtdiVDWnFLKJh70er5L8AlH7uCb4iXrYljyCSAeyr0DiKz6T8ox10NRGPI6iJbYf%2FIr3IuZE1oJgqcvn7tKhQBOq4jemlZpbeQgPy0FxO0%2BDxeqI%3D"
-            in captured.out
-        )
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a newer version of Telerik UI" in captured.out
+    assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert "SUCCESS! Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert ("SUCCESS! Found working version: 2018.1.117") in captured.out
+    assert (
+        "%2Bv%2BRs6kf9lDUYnqqYk32Vg84DkpdruQOKGZRmm6RMkaYuxNmvg5Ca5cT%2F74qkOozHIKkG1ovf6XBsjlp4kgO8BJ6KgNcT78BExQZfT1mN5rMO8kcLDRdffFhFXmvAr0o%2F4x%2B9VoRJVaOyGLXk2nhX4OMP%2BjGP2C96Fa6LyfGWHlk1CF0E5mAPeQ6CLbycR88WU5hlmUUqniXC2UdeYd6HO9RFnISEnhq72MkdiEfvNsqAhr2XaCX2%2BQxFXfCLi2%2Fc%2Bn2NmUiFRdhCLutnVxILEnYiRmU5eHJdB2IOTtoc2XZ3NUdZJwrwOswjzCkk7LOwt2bddTvOXdfWtRrbNz1GDNXlPz1cXotgAhucxLLsknNDbeeboMbL%2Bk3tIeervi7oI%2FRQn6Ml3ffUAfcqHzwcZCEIlQXh%2FBEIKHAY9fGKs5JSdtRbREDI0rh9sH%2B0TmYv444WQyqYpa8pOqtxgC1QRRcsNQcVGFzpyNL2SfKSlLTZi5Q7bo8XMTfLG6jg60csDEDiJ7MwJBGIm1iYzt%2FP9JEKkZujTMyHoBI0RESNpux7BeanEIDsfDmfwbcUo%2B2%2BkoHkCE4zXWBdW3lqssk4GwSbc0mbmf3U79rsQdNEqIOL87evE1U6tGB5PuXgwAIj9sKdyffd8%2B%2Bz1CCffFovLM72ilbCmSljAJ%2BvVBfNpTiL7RV7j3XGygljzi4NL8yXJuCLYiNxmqPMdV8DahLed0jSe2mkU1u6rx4yS3dcWEfwMWjI5tVrfnbqtdInC8TliXkTZ919CtORoydmIXGL1u3kdBIq8EZcjRMa4bN4VTvUlbqeIe8p8QYEQwAi7vXiZCKS6R6dmJfQv%2B%2FqBHXWSFuglLYde019GNtNdGQfEnY31zT0Q86ieDYn4k55LbYq5lK8PNjg50gdJxn9fNtHTQ7frKP9vRM4cImRSvDBTATVw1PDzMqn0exo3xciYd5%2BXYAxlFoqwFMDz40w2xR4OWwoPsixpVjR2DYiqYiZrYytFMjziRCLQhkVuJpED8nB9CTlo05WBKN%2Bb4UBHBg%2FkCkHXJxNakIX7UbAjDcqzrNCGhjrgehCGA81uOf0Ppfswda0ZHMi8g9W6Y7uwWmn7Ux7xBMgDCUNIi8I3UvLGXdKnuB8YHX8TLC1z2%2Fm3ip797Pix1ya2sBsbw9KgOJ7PBT0u9W0puchi7zpT%2FzFe3V2HbV0ottDethRJhzaN856VgvjyNhbbmA04gnal%2Fq01j7LNWxEwTjNPyHORI1l9jztvYqItLei7YQYg2pFhmvuv0Od8DPfH40Y1m3mL2F2d%2FAy3ImzFI%2BKQB6mnGPvRcDIS1j7zPhciKRuLfu3dCxhIH7ojo83rhQus3SyXdyZ5cjkFKcG3H7WmBBMOFs2o5xjWcdLARevRbNbqwRfATerc5GuJxy1Qb8RJvOqhDcS5YAHyxVMx2QYU3yMhg0tCpy4wW%2FHsa33feu3NeBu9lRI38ojJNM7o6xYRoSTQu4tYadB4Yh4w60e%2FsttnecOC5plZrLw6BYN2piqvUD07BnO4yTvrpdBDXR%2BMFDchnFh2YK9JtvvtAISvpoSOJojOhwRKuafCwEJn0GB1dsdmOOxxaFHkPXQ7789eCxlTL5mkVf3ktzmHQdDyBxBlDLFWSjmFIBHp%2BPobFdDOmv5p6J3%2F%2FM23PMgGDLRMrj5LVZV3trGV1ZaJHEFIGmVwW0tN4426Q4rCdcxT4ju%2B%2FNhcq90e8crWw9nrF2rPTzW1YM7VqWWwhLj8MtVtGZFa3N%2FxdjEys8FWyT8VqAbC4IltuT5lW1ou1SXsA96h%2F9y3vzJADbm4Lv624OGnh6M%2FCmR930i6YeUlWWmMw1%2FpcZ5werHPm9v0OWulNmGfbNEoKuThz2sSCZ8FLNVToygv1VXPXnur4dJnoCkwBP2%2BQQ6%2FHlyFRXnrrGsiDJE3qtRXgECIhc2zpuC5HAz9FhIfC9VZZ5nxRMbhA6W%2Fz%2BjPpKLCBpmLqHJfy8%2B%2FausiZJv7d9yQ0SvHtq0y%2FSY04hOgZTJul6IIYpObD6s%2FqrGy2nMmY3%2FtEn830%2F%2BFERnXMeBsj%2B%2F5ZSewYe4xBnub1wvSbsA3qjoU5gq7fhDJOhmMQXkbas%2FRholsU9CNKNXpSyqVarqAc8XwaG34JmdG3wjQXd6p%2Bz2jZLew5ja8nelvVdIeN%2F9ejCNOoXcPApYLHyxslcrEuJrSHlAMR4FbonfrFhYYTR%2B8pdxRGYGpVUDxlIRvayztxVhLnSpRwg5uIXktoMwJ%2FSaF8x29hA9LIyUqAu4%2FR2hQW%2B4SImPpsXXpqtiGkjfub23eHBh6%2BtPfI7KNBt0Sz%2F3IcUvQk%2BWZYFfPMd8cXJdempaxEs%2BWRlN16p%2BjqhLiVh2A8iaZ4WvdHZmEP7slp3BgAJHjnl7C9sEWeDqCEwe%2FjIDLeJ1X%2FDjBXwflC7CNUtfL5Xw3En%2FArqlvVhUGhwvFy6lQocBfs6%2BLYvOaWiwZ37DX8rkRZlWpkY2rpapUrmnba7Ly%2FoLx924DzkK78M%2BzFL0ra5b1t6Rgv5zuibZAhF47t1EdOxpWIlBlf3zB9gg2M5Rk%2F9IMH%2BzrDHou9o9uO%2BDC6WFddIOuEWc1nrjSenwFkvqgNVdc9CtdiVDWnFLKJh70er5L8AlH7uCb4iXrYljyCSAeyr0DiKz6T8ox10NRGPI6iJbYf%2FIr3IuZE1oJgqcvn7tKhQBOq4jemlZpbeQgPy0FxO0%2BDxeqI%3D"
+        in captured.out
+    )
 
 
-def test_fullrun_PBKDF2_version_customkeys(monkeypatch, capsys, mocker):
+def test_fullrun_PBKDF2_version_customkeys(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(["Not_The_Real_Encryption_Key", "another_fake_encryption_key"])
 
@@ -349,58 +356,60 @@ def test_fullrun_PBKDF2_version_customkeys(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF2_version_probe_matcher_incorrect(request):
-                return httpx.Response(
-                    200,
-                    text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF2_version_probe_matcher(request):
-                return httpx.Response(200, text="DoesntMatter")
-            if PBKDF2_found_key_matcher_negative(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
-                )
-            if PBKDF2_found_key_matcher(request):
-                return httpx.Response(
-                    200,
-                    text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF2_version_probe_matcher_incorrect(request):
+            return MockResponse(
+                status_code=200,
+                text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF2_version_probe_matcher(request):
+            return MockResponse(status_code=200, text="DoesntMatter")
+        if PBKDF2_found_key_matcher_negative(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
+            )
+        if PBKDF2_found_key_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
-                "--version",
-                "2018.1.117",
-                "--custom-keys",
-                "d2a312d9-7af4-43de-be5a-ae717b46cea6,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
-            ],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a newer version of Telerik UI" in captured.out
-        assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert "SUCCESS! Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert ("SUCCESS! Found working version: 2018.1.117") in captured.out
-        assert (
-            "%2Bv%2BRs6kf9lDUYnqqYk32Vg84DkpdruQOKGZRmm6RMkaYuxNmvg5Ca5cT%2F74qkOozHIKkG1ovf6XBsjlp4kgO8BJ6KgNcT78BExQZfT1mN5rMO8kcLDRdffFhFXmvAr0o%2F4x%2B9VoRJVaOyGLXk2nhX4OMP%2BjGP2C96Fa6LyfGWHlk1CF0E5mAPeQ6CLbycR88WU5hlmUUqniXC2UdeYd6HO9RFnISEnhq72MkdiEfvNsqAhr2XaCX2%2BQxFXfCLi2%2Fc%2Bn2NmUiFRdhCLutnVxILEnYiRmU5eHJdB2IOTtoc2XZ3NUdZJwrwOswjzCkk7LOwt2bddTvOXdfWtRrbNz1GDNXlPz1cXotgAhucxLLsknNDbeeboMbL%2Bk3tIeervi7oI%2FRQn6Ml3ffUAfcqHzwcZCEIlQXh%2FBEIKHAY9fGKs5JSdtRbREDI0rh9sH%2B0TmYv444WQyqYpa8pOqtxgC1QRRcsNQcVGFzpyNL2SfKSlLTZi5Q7bo8XMTfLG6jg60csDEDiJ7MwJBGIm1iYzt%2FP9JEKkZujTMyHoBI0RESNpux7BeanEIDsfDmfwbcUo%2B2%2BkoHkCE4zXWBdW3lqssk4GwSbc0mbmf3U79rsQdNEqIOL87evE1U6tGB5PuXgwAIj9sKdyffd8%2B%2Bz1CCffFovLM72ilbCmSljAJ%2BvVBfNpTiL7RV7j3XGygljzi4NL8yXJuCLYiNxmqPMdV8DahLed0jSe2mkU1u6rx4yS3dcWEfwMWjI5tVrfnbqtdInC8TliXkTZ919CtORoydmIXGL1u3kdBIq8EZcjRMa4bN4VTvUlbqeIe8p8QYEQwAi7vXiZCKS6R6dmJfQv%2B%2FqBHXWSFuglLYde019GNtNdGQfEnY31zT0Q86ieDYn4k55LbYq5lK8PNjg50gdJxn9fNtHTQ7frKP9vRM4cImRSvDBTATVw1PDzMqn0exo3xciYd5%2BXYAxlFoqwFMDz40w2xR4OWwoPsixpVjR2DYiqYiZrYytFMjziRCLQhkVuJpED8nB9CTlo05WBKN%2Bb4UBHBg%2FkCkHXJxNakIX7UbAjDcqzrNCGhjrgehCGA81uOf0Ppfswda0ZHMi8g9W6Y7uwWmn7Ux7xBMgDCUNIi8I3UvLGXdKnuB8YHX8TLC1z2%2Fm3ip797Pix1ya2sBsbw9KgOJ7PBT0u9W0puchi7zpT%2FzFe3V2HbV0ottDethRJhzaN856VgvjyNhbbmA04gnal%2Fq01j7LNWxEwTjNPyHORI1l9jztvYqItLei7YQYg2pFhmvuv0Od8DPfH40Y1m3mL2F2d%2FAy3ImzFI%2BKQB6mnGPvRcDIS1j7zPhciKRuLfu3dCxhIH7ojo83rhQus3SyXdyZ5cjkFKcG3H7WmBBMOFs2o5xjWcdLARevRbNbqwRfATerc5GuJxy1Qb8RJvOqhDcS5YAHyxVMx2QYU3yMhg0tCpy4wW%2FHsa33feu3NeBu9lRI38ojJNM7o6xYRoSTQu4tYadB4Yh4w60e%2FsttnecOC5plZrLw6BYN2piqvUD07BnO4yTvrpdBDXR%2BMFDchnFh2YK9JtvvtAISvpoSOJojOhwRKuafCwEJn0GB1dsdmOOxxaFHkPXQ7789eCxlTL5mkVf3ktzmHQdDyBxBlDLFWSjmFIBHp%2BPobFdDOmv5p6J3%2F%2FM23PMgGDLRMrj5LVZV3trGV1ZaJHEFIGmVwW0tN4426Q4rCdcxT4ju%2B%2FNhcq90e8crWw9nrF2rPTzW1YM7VqWWwhLj8MtVtGZFa3N%2FxdjEys8FWyT8VqAbC4IltuT5lW1ou1SXsA96h%2F9y3vzJADbm4Lv624OGnh6M%2FCmR930i6YeUlWWmMw1%2FpcZ5werHPm9v0OWulNmGfbNEoKuThz2sSCZ8FLNVToygv1VXPXnur4dJnoCkwBP2%2BQQ6%2FHlyFRXnrrGsiDJE3qtRXgECIhc2zpuC5HAz9FhIfC9VZZ5nxRMbhA6W%2Fz%2BjPpKLCBpmLqHJfy8%2B%2FausiZJv7d9yQ0SvHtq0y%2FSY04hOgZTJul6IIYpObD6s%2FqrGy2nMmY3%2FtEn830%2F%2BFERnXMeBsj%2B%2F5ZSewYe4xBnub1wvSbsA3qjoU5gq7fhDJOhmMQXkbas%2FRholsU9CNKNXpSyqVarqAc8XwaG34JmdG3wjQXd6p%2Bz2jZLew5ja8nelvVdIeN%2F9ejCNOoXcPApYLHyxslcrEuJrSHlAMR4FbonfrFhYYTR%2B8pdxRGYGpVUDxlIRvayztxVhLnSpRwg5uIXktoMwJ%2FSaF8x29hA9LIyUqAu4%2FR2hQW%2B4SImPpsXXpqtiGkjfub23eHBh6%2BtPfI7KNBt0Sz%2F3IcUvQk%2BWZYFfPMd8cXJdempaxEs%2BWRlN16p%2BjqhLiVh2A8iaZ4WvdHZmEP7slp3BgAJHjnl7C9sEWeDqCEwe%2FjIDLeJ1X%2FDjBXwflC7CNUtfL5Xw3En%2FArqlvVhUGhwvFy6lQocBfs6%2BLYvOaWiwZ37DX8rkRZlWpkY2rpapUrmnba7Ly%2FoLx924DzkK78M%2BzFL0ra5b1t6Rgv5zuibZAhF47t1EdOxpWIlBlf3zB9gg2M5Rk%2F9IMH%2BzrDHou9o9uO%2BDC6WFddIOuEWc1nrjSenwFkvqgNVdc9CtdiVDWnFLKJh70er5L8AlH7uCb4iXrYljyCSAeyr0DiKz6T8ox10NRGPI6iJbYf%2FIr3IuZE1oJgqcvn7tKhQBOq4jemlZpbeQgPy0FxO0%2BDxeqI%3D"
-            in captured.out
-        )
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+            "--version",
+            "2018.1.117",
+            "--custom-keys",
+            "d2a312d9-7af4-43de-be5a-ae717b46cea6,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
+        ],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a newer version of Telerik UI" in captured.out
+    assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert "SUCCESS! Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert ("SUCCESS! Found working version: 2018.1.117") in captured.out
+    assert (
+        "%2Bv%2BRs6kf9lDUYnqqYk32Vg84DkpdruQOKGZRmm6RMkaYuxNmvg5Ca5cT%2F74qkOozHIKkG1ovf6XBsjlp4kgO8BJ6KgNcT78BExQZfT1mN5rMO8kcLDRdffFhFXmvAr0o%2F4x%2B9VoRJVaOyGLXk2nhX4OMP%2BjGP2C96Fa6LyfGWHlk1CF0E5mAPeQ6CLbycR88WU5hlmUUqniXC2UdeYd6HO9RFnISEnhq72MkdiEfvNsqAhr2XaCX2%2BQxFXfCLi2%2Fc%2Bn2NmUiFRdhCLutnVxILEnYiRmU5eHJdB2IOTtoc2XZ3NUdZJwrwOswjzCkk7LOwt2bddTvOXdfWtRrbNz1GDNXlPz1cXotgAhucxLLsknNDbeeboMbL%2Bk3tIeervi7oI%2FRQn6Ml3ffUAfcqHzwcZCEIlQXh%2FBEIKHAY9fGKs5JSdtRbREDI0rh9sH%2B0TmYv444WQyqYpa8pOqtxgC1QRRcsNQcVGFzpyNL2SfKSlLTZi5Q7bo8XMTfLG6jg60csDEDiJ7MwJBGIm1iYzt%2FP9JEKkZujTMyHoBI0RESNpux7BeanEIDsfDmfwbcUo%2B2%2BkoHkCE4zXWBdW3lqssk4GwSbc0mbmf3U79rsQdNEqIOL87evE1U6tGB5PuXgwAIj9sKdyffd8%2B%2Bz1CCffFovLM72ilbCmSljAJ%2BvVBfNpTiL7RV7j3XGygljzi4NL8yXJuCLYiNxmqPMdV8DahLed0jSe2mkU1u6rx4yS3dcWEfwMWjI5tVrfnbqtdInC8TliXkTZ919CtORoydmIXGL1u3kdBIq8EZcjRMa4bN4VTvUlbqeIe8p8QYEQwAi7vXiZCKS6R6dmJfQv%2B%2FqBHXWSFuglLYde019GNtNdGQfEnY31zT0Q86ieDYn4k55LbYq5lK8PNjg50gdJxn9fNtHTQ7frKP9vRM4cImRSvDBTATVw1PDzMqn0exo3xciYd5%2BXYAxlFoqwFMDz40w2xR4OWwoPsixpVjR2DYiqYiZrYytFMjziRCLQhkVuJpED8nB9CTlo05WBKN%2Bb4UBHBg%2FkCkHXJxNakIX7UbAjDcqzrNCGhjrgehCGA81uOf0Ppfswda0ZHMi8g9W6Y7uwWmn7Ux7xBMgDCUNIi8I3UvLGXdKnuB8YHX8TLC1z2%2Fm3ip797Pix1ya2sBsbw9KgOJ7PBT0u9W0puchi7zpT%2FzFe3V2HbV0ottDethRJhzaN856VgvjyNhbbmA04gnal%2Fq01j7LNWxEwTjNPyHORI1l9jztvYqItLei7YQYg2pFhmvuv0Od8DPfH40Y1m3mL2F2d%2FAy3ImzFI%2BKQB6mnGPvRcDIS1j7zPhciKRuLfu3dCxhIH7ojo83rhQus3SyXdyZ5cjkFKcG3H7WmBBMOFs2o5xjWcdLARevRbNbqwRfATerc5GuJxy1Qb8RJvOqhDcS5YAHyxVMx2QYU3yMhg0tCpy4wW%2FHsa33feu3NeBu9lRI38ojJNM7o6xYRoSTQu4tYadB4Yh4w60e%2FsttnecOC5plZrLw6BYN2piqvUD07BnO4yTvrpdBDXR%2BMFDchnFh2YK9JtvvtAISvpoSOJojOhwRKuafCwEJn0GB1dsdmOOxxaFHkPXQ7789eCxlTL5mkVf3ktzmHQdDyBxBlDLFWSjmFIBHp%2BPobFdDOmv5p6J3%2F%2FM23PMgGDLRMrj5LVZV3trGV1ZaJHEFIGmVwW0tN4426Q4rCdcxT4ju%2B%2FNhcq90e8crWw9nrF2rPTzW1YM7VqWWwhLj8MtVtGZFa3N%2FxdjEys8FWyT8VqAbC4IltuT5lW1ou1SXsA96h%2F9y3vzJADbm4Lv624OGnh6M%2FCmR930i6YeUlWWmMw1%2FpcZ5werHPm9v0OWulNmGfbNEoKuThz2sSCZ8FLNVToygv1VXPXnur4dJnoCkwBP2%2BQQ6%2FHlyFRXnrrGsiDJE3qtRXgECIhc2zpuC5HAz9FhIfC9VZZ5nxRMbhA6W%2Fz%2BjPpKLCBpmLqHJfy8%2B%2FausiZJv7d9yQ0SvHtq0y%2FSY04hOgZTJul6IIYpObD6s%2FqrGy2nMmY3%2FtEn830%2F%2BFERnXMeBsj%2B%2F5ZSewYe4xBnub1wvSbsA3qjoU5gq7fhDJOhmMQXkbas%2FRholsU9CNKNXpSyqVarqAc8XwaG34JmdG3wjQXd6p%2Bz2jZLew5ja8nelvVdIeN%2F9ejCNOoXcPApYLHyxslcrEuJrSHlAMR4FbonfrFhYYTR%2B8pdxRGYGpVUDxlIRvayztxVhLnSpRwg5uIXktoMwJ%2FSaF8x29hA9LIyUqAu4%2FR2hQW%2B4SImPpsXXpqtiGkjfub23eHBh6%2BtPfI7KNBt0Sz%2F3IcUvQk%2BWZYFfPMd8cXJdempaxEs%2BWRlN16p%2BjqhLiVh2A8iaZ4WvdHZmEP7slp3BgAJHjnl7C9sEWeDqCEwe%2FjIDLeJ1X%2FDjBXwflC7CNUtfL5Xw3En%2FArqlvVhUGhwvFy6lQocBfs6%2BLYvOaWiwZ37DX8rkRZlWpkY2rpapUrmnba7Ly%2FoLx924DzkK78M%2BzFL0ra5b1t6Rgv5zuibZAhF47t1EdOxpWIlBlf3zB9gg2M5Rk%2F9IMH%2BzrDHou9o9uO%2BDC6WFddIOuEWc1nrjSenwFkvqgNVdc9CtdiVDWnFLKJh70er5L8AlH7uCb4iXrYljyCSAeyr0DiKz6T8ox10NRGPI6iJbYf%2FIr3IuZE1oJgqcvn7tKhQBOq4jemlZpbeQgPy0FxO0%2BDxeqI%3D"
+        in captured.out
+    )
 
 
-def test_fullrun_PBKDF2_modern_dialog_params(monkeypatch, capsys, mocker):
+def test_fullrun_PBKDF2_modern_dialog_params(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(
             ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
@@ -412,57 +421,59 @@ def test_fullrun_PBKDF2_modern_dialog_params(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF2_version_probe_matcher_incorrect_modern(request):
-                return httpx.Response(
-                    200,
-                    text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF2_version_probe_matcher_modern(request):
-                return httpx.Response(200, text="DoesntMatter")
-            if PBKDF2_found_key_matcher_negative(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
-                )
-            if PBKDF2_found_key_matcher(request):
-                return httpx.Response(
-                    200,
-                    text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF2_version_probe_matcher_incorrect_modern(request):
+            return MockResponse(
+                status_code=200,
+                text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF2_version_probe_matcher_modern(request):
+            return MockResponse(status_code=200, text="DoesntMatter")
+        if PBKDF2_found_key_matcher_negative(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
+            )
+        if PBKDF2_found_key_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
-                "--version",
-                "2018.1.117",
-                "--modern-dialog-params",
-            ],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a newer version of Telerik UI" in captured.out
-        assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert "SUCCESS! Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert ("SUCCESS! Found working version: 2018.1.117") in captured.out
-        assert (
-            "%2Bv%2BRs6kf9lDUYnqqYk32Vg84DkpdruQOKGZRmm6RMkaYuxNmvg5Ca5cT%2F74qkOozHIKkG1ovf6XBsjlp4kgO8BJ6KgNcT78BExQZfT1mN5rMO8kcLDRdffFhFXmvAr0o%2F4x%2B9VoRJVaOyGLXk2nhX4OMP%2BjGP2C96Fa6LyfGWHlk1CF0E5mAPeQ6CLbycR88WU5hlmUUqniXC2UdeYd6HO9RFnISEnhq72MkdiEfvNsqAhr2XaCX2%2BQxFXfCLi2%2Fc%2Bn2NmUiFRdhCLutnVxILEnYiRmU5eHJdB2IOTtoc2XZ3NUdZJwrwOswjzCkk7LOwt2bddTvOXdfWtRrbNz1GDNXlPz1cXotgAhucxLLsknNDbeeboMbL%2Bk3tIeervi7oI%2FRQn6Ml3ffUAfcqHzwcXSXq6ey16mT7GUJbst%2BCQnfUQu5gqzYBOwSmvNPc9AtoVWV%2F5dfO1uPm%2F%2FfLxuOXoxO5v7UIJNIX1KUEuFcysdbBSkZHdCqSRasDt63Li1lZEqHBCuHSNj%2BcEcRGx841w%2BCN%2BWrJyanc%2F3OOP%2BNWRYRstLeKZVf3aRHhKYNp4Q%2B%2BSEQxIVpv9UxWpkOSs%2Bbckk36t3N6DCcKGB1z9lelAGTDzlOLPUh9GhikJAESqLytLBC0CXn40%2BI%2BlBRZ44m4TX53YDcKBPOfiP880p3%2BfnIOY1X6p7HMNoi5jcUlphEQv5aN60B7TkYzZVRQS6xX0gq8r1La9iEUeE4t8378DhGQ8qkcHv1JkJM4WBgQaFzfWxj5Dg%2BL7USGaCKNH4W0kzeBSNrRW5ETwJDrDh683%2BzOJCEqh5Wlqjswo4986yHARJEJzRgJC2O4EbGcGyBtiaNioPFUyyX87ovcxMqIdMEyfZpo5QeWd4s0Sufx4vICyl%2BkGtzo0f7xIhIeuJRsbXvKmHxx0wwVJZsOFR5SBYrd7%2Bs6TM8waDsXr5pC%2FdTT3pBCh%2BWPS%2Fy%2FMgHjh75q6lWy4UTygpb6brMqiW%2F%2F1NXRLLHqqweT8xy5N0x7ck8bspjo7yF1rNn%2FixyuQ7HLZsEiXEbwBCBGGnTF2P4geoz9t7y7wUdoRw5SDyhSqoS2X5Urwou8KNAN4kY20JNgoM8L3ef8TcHctE2vwQ0jvCLxec%2FC3hr61NyO8QVxi8KzJvjRaHqkDkzJ5GQ3N1JLfA7Mdg%2FZTRzu2C7v5ubmJPR%2BiA24xOoKUvsYJQ0KiXRkWdGG5bprG4DjFWgkrGVh0yH4lj5R97BQ0uIIZehSQXibhI9RiANf459jDJN3eTQ6mcpYkvz%2FW0GnHKRgjcqRFqXnqsUdEHnuUkmZvdhbyRdPrkHvn99RhVmX4QXHYO0ehZVXknk42D5euG0acZMSyygTXrZZNu6e%2BriIrlmMGQgKuwN%2FNVz%2Bocl987zG%2Fmf7r%2FRz1ZSXkNtixN7LQwpZ%2BCM7zP64ugTT%2FWoo76hZgf5PjlW3C9k8tIPXEVT6HKIzteaP6YrviJCuy8VAybH5t1aDY%2FGl5MXiFjfGZNf3921yvTlwmWOi0oUFky5460M1RYwt4UHkwmFIAIJF4TN5kIu%2FaJxYHTCG%2BC14r7TjVPJuy%2FI2iYEJOA58G9yOevW6ixm650ELGqXXgbRRUH3hec6j%2FrRdrNdPU7isX%2FBBicEACDS97uvz62YkJwwJ5AUEnfuV%2FhnlJzIjNC%2Fq7xAb2sXuv6HTdtJYaJbe5%2BXWwq0AppO5NV9oU2cD%2F%2F1JhRN6GZ3myMGYGwDRYdPIqJ0l9PUCetBrSQR7830WkfGJ%2FHfuIWH%2F45zGsixZXYwHfE90rVvCisAjJ%2BBsjYX%2BKSx3PXAg2%2BKzybzyd6m%2B6ArimL%2FwWXF4t6eEFOrzKL8zYzNMDlKab6rgFhXPYw%2Bseulb9lwi90MlPoBmDjuEDJxtD7tNYMd3yWBIYyVN3Pv6adra6cKizf8zGBTl3ofs%2Fj5v2wjb1Dp33tbcASpHAL0rfyns7O%2Bm%2BZRAtn1tr5JRFSseu%2BqNXCiFCr2Oc3%2FCseGewyQhMqBkcPDOxfRvPMNdQhR4e92EDnFV1a%2FzJKSf%2BvqBzDiAeqBojmIjUppKBPtDTs0J%2B6UIPzkO8z5Ff%2BstJwF%2FplkftFk6CpAvDITRDgKgbMJ%2BVB8CqeOF2%2FS3Q4LEcLxxUUTgUvEQb9OxVWzd7YDTSAvcCvc3y9T3d0bJxJ0%2BGjZO2ZbnB7tDgBmC4clqtwp3m2JyFWOWzzkmLx16bfgA259Piju0qHZKFtQaASrFTy2QxM0MmyXpgcBWZgiubyta4%2B6d9YkgMQp4tcsL6k1HLYGRHujkaixzdVgjvXwsQ0EqYeX5RM2vzWaPhxSK%2BnsjxgiURZbj5wWvVQPml9RHnTdyYRvELRAqxPCFhYFQ%2BpEIwUHwEuvgkvgmyHjN3ZspADp%2BcO9B9VoAFmLg74jkcifZJqy2WpIPTL6JASkn9A2UgmmnAAqmu%2BwEayHVtrBGrpswqeKT3q7JttEn5YbbWYN%2FLyOtVG5VCBoxjP3XFTcLV0wcXHSrm6EMPkzi%2Bqv%2BYHUBJQ43YycfduyjZuWw9jmU4wm8O%2BIFVsaSxmmxnsQ2jAotpr%2BxUZXTjInv8TvHuO4xaLqyifS%2B7Ht1wAwrXtcfseEkkCVwRLib5F%2FEMIWWDrYpKWx5fYZjBNlhMb21WvehQkeVu71jK%2FUdqV%2BBVfT8yjHbk7vaxxxiewLXV7LP3D56LPD8koeIwptkJ62JHFBjnlvR9XHZowkiPZZ3X7BV3S6S6t5TIjDHVeuO3PZnSv9ic0BGb8Srbq2eABgsmOXPKTHgaTAFzUTa8axECwKYWQfZvJRnDrvP8qt34C2Y9tDa1THJqdtb3x3Qco6exHd5WpH2LcR0j1fc4ZJDocOXnZaQKyvDlMTZIfA4O2WzeECxHIJIe2ulebZpJHCX3bFtBrlmy45z4pwbl%2BcUBzLLpzn8Ro7g5427G3aj%2Ftn5s1K42yMbrcNCbaSPK4SnCAA9%2BkKqwcoatuiyi3fy7vhOAgP0BNNFRO8LjLsJth%2BfRRQDTNLD0jUKPtS7DtAKck3h30%2FRFJj4QYLYeQ%3D"
-            in captured.out
-        )
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+            "--version",
+            "2018.1.117",
+            "--modern-dialog-params",
+        ],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a newer version of Telerik UI" in captured.out
+    assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert "SUCCESS! Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert ("SUCCESS! Found working version: 2018.1.117") in captured.out
+    assert (
+        "%2Bv%2BRs6kf9lDUYnqqYk32Vg84DkpdruQOKGZRmm6RMkaYuxNmvg5Ca5cT%2F74qkOozHIKkG1ovf6XBsjlp4kgO8BJ6KgNcT78BExQZfT1mN5rMO8kcLDRdffFhFXmvAr0o%2F4x%2B9VoRJVaOyGLXk2nhX4OMP%2BjGP2C96Fa6LyfGWHlk1CF0E5mAPeQ6CLbycR88WU5hlmUUqniXC2UdeYd6HO9RFnISEnhq72MkdiEfvNsqAhr2XaCX2%2BQxFXfCLi2%2Fc%2Bn2NmUiFRdhCLutnVxILEnYiRmU5eHJdB2IOTtoc2XZ3NUdZJwrwOswjzCkk7LOwt2bddTvOXdfWtRrbNz1GDNXlPz1cXotgAhucxLLsknNDbeeboMbL%2Bk3tIeervi7oI%2FRQn6Ml3ffUAfcqHzwcXSXq6ey16mT7GUJbst%2BCQnfUQu5gqzYBOwSmvNPc9AtoVWV%2F5dfO1uPm%2F%2FfLxuOXoxO5v7UIJNIX1KUEuFcysdbBSkZHdCqSRasDt63Li1lZEqHBCuHSNj%2BcEcRGx841w%2BCN%2BWrJyanc%2F3OOP%2BNWRYRstLeKZVf3aRHhKYNp4Q%2B%2BSEQxIVpv9UxWpkOSs%2Bbckk36t3N6DCcKGB1z9lelAGTDzlOLPUh9GhikJAESqLytLBC0CXn40%2BI%2BlBRZ44m4TX53YDcKBPOfiP880p3%2BfnIOY1X6p7HMNoi5jcUlphEQv5aN60B7TkYzZVRQS6xX0gq8r1La9iEUeE4t8378DhGQ8qkcHv1JkJM4WBgQaFzfWxj5Dg%2BL7USGaCKNH4W0kzeBSNrRW5ETwJDrDh683%2BzOJCEqh5Wlqjswo4986yHARJEJzRgJC2O4EbGcGyBtiaNioPFUyyX87ovcxMqIdMEyfZpo5QeWd4s0Sufx4vICyl%2BkGtzo0f7xIhIeuJRsbXvKmHxx0wwVJZsOFR5SBYrd7%2Bs6TM8waDsXr5pC%2FdTT3pBCh%2BWPS%2Fy%2FMgHjh75q6lWy4UTygpb6brMqiW%2F%2F1NXRLLHqqweT8xy5N0x7ck8bspjo7yF1rNn%2FixyuQ7HLZsEiXEbwBCBGGnTF2P4geoz9t7y7wUdoRw5SDyhSqoS2X5Urwou8KNAN4kY20JNgoM8L3ef8TcHctE2vwQ0jvCLxec%2FC3hr61NyO8QVxi8KzJvjRaHqkDkzJ5GQ3N1JLfA7Mdg%2FZTRzu2C7v5ubmJPR%2BiA24xOoKUvsYJQ0KiXRkWdGG5bprG4DjFWgkrGVh0yH4lj5R97BQ0uIIZehSQXibhI9RiANf459jDJN3eTQ6mcpYkvz%2FW0GnHKRgjcqRFqXnqsUdEHnuUkmZvdhbyRdPrkHvn99RhVmX4QXHYO0ehZVXknk42D5euG0acZMSyygTXrZZNu6e%2BriIrlmMGQgKuwN%2FNVz%2Bocl987zG%2Fmf7r%2FRz1ZSXkNtixN7LQwpZ%2BCM7zP64ugTT%2FWoo76hZgf5PjlW3C9k8tIPXEVT6HKIzteaP6YrviJCuy8VAybH5t1aDY%2FGl5MXiFjfGZNf3921yvTlwmWOi0oUFky5460M1RYwt4UHkwmFIAIJF4TN5kIu%2FaJxYHTCG%2BC14r7TjVPJuy%2FI2iYEJOA58G9yOevW6ixm650ELGqXXgbRRUH3hec6j%2FrRdrNdPU7isX%2FBBicEACDS97uvz62YkJwwJ5AUEnfuV%2FhnlJzIjNC%2Fq7xAb2sXuv6HTdtJYaJbe5%2BXWwq0AppO5NV9oU2cD%2F%2F1JhRN6GZ3myMGYGwDRYdPIqJ0l9PUCetBrSQR7830WkfGJ%2FHfuIWH%2F45zGsixZXYwHfE90rVvCisAjJ%2BBsjYX%2BKSx3PXAg2%2BKzybzyd6m%2B6ArimL%2FwWXF4t6eEFOrzKL8zYzNMDlKab6rgFhXPYw%2Bseulb9lwi90MlPoBmDjuEDJxtD7tNYMd3yWBIYyVN3Pv6adra6cKizf8zGBTl3ofs%2Fj5v2wjb1Dp33tbcASpHAL0rfyns7O%2Bm%2BZRAtn1tr5JRFSseu%2BqNXCiFCr2Oc3%2FCseGewyQhMqBkcPDOxfRvPMNdQhR4e92EDnFV1a%2FzJKSf%2BvqBzDiAeqBojmIjUppKBPtDTs0J%2B6UIPzkO8z5Ff%2BstJwF%2FplkftFk6CpAvDITRDgKgbMJ%2BVB8CqeOF2%2FS3Q4LEcLxxUUTgUvEQb9OxVWzd7YDTSAvcCvc3y9T3d0bJxJ0%2BGjZO2ZbnB7tDgBmC4clqtwp3m2JyFWOWzzkmLx16bfgA259Piju0qHZKFtQaASrFTy2QxM0MmyXpgcBWZgiubyta4%2B6d9YkgMQp4tcsL6k1HLYGRHujkaixzdVgjvXwsQ0EqYeX5RM2vzWaPhxSK%2BnsjxgiURZbj5wWvVQPml9RHnTdyYRvELRAqxPCFhYFQ%2BpEIwUHwEuvgkvgmyHjN3ZspADp%2BcO9B9VoAFmLg74jkcifZJqy2WpIPTL6JASkn9A2UgmmnAAqmu%2BwEayHVtrBGrpswqeKT3q7JttEn5YbbWYN%2FLyOtVG5VCBoxjP3XFTcLV0wcXHSrm6EMPkzi%2Bqv%2BYHUBJQ43YycfduyjZuWw9jmU4wm8O%2BIFVsaSxmmxnsQ2jAotpr%2BxUZXTjInv8TvHuO4xaLqyifS%2B7Ht1wAwrXtcfseEkkCVwRLib5F%2FEMIWWDrYpKWx5fYZjBNlhMb21WvehQkeVu71jK%2FUdqV%2BBVfT8yjHbk7vaxxxiewLXV7LP3D56LPD8koeIwptkJ62JHFBjnlvR9XHZowkiPZZ3X7BV3S6S6t5TIjDHVeuO3PZnSv9ic0BGb8Srbq2eABgsmOXPKTHgaTAFzUTa8axECwKYWQfZvJRnDrvP8qt34C2Y9tDa1THJqdtb3x3Qco6exHd5WpH2LcR0j1fc4ZJDocOXnZaQKyvDlMTZIfA4O2WzeECxHIJIe2ulebZpJHCX3bFtBrlmy45z4pwbl%2BcUBzLLpzn8Ro7g5427G3aj%2Ftn5s1K42yMbrcNCbaSPK4SnCAA9%2BkKqwcoatuiyi3fy7vhOAgP0BNNFRO8LjLsJth%2BfRRQDTNLD0jUKPtS7DtAKck3h30%2FRFJj4QYLYeQ%3D"
+        in captured.out
+    )
 
 
-def test_nomatch_PBKDF2(monkeypatch, capsys, mocker):
+def test_nomatch_PBKDF2(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(
             ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
@@ -474,54 +485,56 @@ def test_nomatch_PBKDF2(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik presence
-        respx.get("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik presence
+    bh_mock.add_response(
+        url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF2_version_probe_matcher_incorrect(request):
-                return httpx.Response(
-                    200,
-                    text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF2_version_probe_matcher(request):
-                return httpx.Response(200, text="DoesntMatter")
-            if PBKDF2_found_key_matcher_negative(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
-                )
-            if PBKDF2_found_key_matcher(request):
-                return httpx.Response(
-                    200,
-                    text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF2_version_probe_matcher_incorrect(request):
+            return MockResponse(
+                status_code=200,
+                text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF2_version_probe_matcher(request):
+            return MockResponse(status_code=200, text="DoesntMatter")
+        if PBKDF2_found_key_matcher_negative(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
+            )
+        if PBKDF2_found_key_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
-                "--machine-keys",
-                "--debug",
-            ],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a newer version of Telerik UI" in captured.out
-        assert (
-            "WARNING: MachineKeys inclusion mode is enabled, which affects this Telerik version particularly dramatically. Brute Forcing will be VERY SLOW"
-            in captured.out
-        )
-        print(captured.out)
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+            "--machine-keys",
+            "--debug",
+        ],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a newer version of Telerik UI" in captured.out
+    assert (
+        "WARNING: MachineKeys inclusion mode is enabled, which affects this Telerik version particularly dramatically. Brute Forcing will be VERY SLOW"
+        in captured.out
+    )
+    print(captured.out)
 
 
-def test_fullrun_PBKDF1_MS(monkeypatch, capsys, mocker):
+def test_fullrun_PBKDF1_MS(monkeypatch, capsys, mocker, bh_mock):
     mocker.patch.object(
         Telerik_EncryptionKey,
         "prepare_keylist",
@@ -535,47 +548,53 @@ def test_fullrun_PBKDF1_MS(monkeypatch, capsys, mocker):
         return_value=iter(["Not_The_Real_HaSh_Key", "YOUR_ENCRYPTION_KEY_TO_GO_HERE", "Y3t_anoth3r_f@k3_key"]),
     )
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF1_MS_version_probe_matcher_incorrect(request):
-                return httpx.Response(
-                    200,
-                    text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF1_MS_encryption_probe_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:Index was outside the bounds of the array.</div>")
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(200, text="Error Message:Length cannot be less than zero")
-            if PBKDF1_MS_found_key_matcher_negative(request):
-                return httpx.Response(200, text="<div>Error Message:The hash is not valid!</div>")
-            if PBKDF1_MS_found_key_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:The input data is not a complete block.</div>")
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF1_MS_version_probe_matcher_incorrect(request):
+            return MockResponse(
+                status_code=200,
+                text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF1_MS_encryption_probe_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Index was outside the bounds of the array.</div>"
+            )
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(status_code=200, text="Error Message:Length cannot be less than zero")
+        if PBKDF1_MS_found_key_matcher_negative(request):
+            return MockResponse(status_code=200, text="<div>Error Message:The hash is not valid!</div>")
+        if PBKDF1_MS_found_key_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:The input data is not a complete block.</div>"
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a valid DialogHandler endpoint. Brute forcing Telerik Hash Key" in captured.out
-        assert "Found matching hashkey: [YOUR_ENCRYPTION_KEY_TO_GO_HERE]" in captured.out
-        assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert "Found Telerik Version! [2018.1.117]" in captured.out
-        assert (
-            "gRRgyE4BOGtN%2FLtBxeEeJDuLj%2FUwIG4oBhO5rCDfPjeH10P8Y02mDK3B%2FtsdOIrwILK7XjQiuTlTZMgHckSyb518JPAo6evNlVTPWD5AZX5l4UIUkfdJvq28UHyeBA4eC58PfA6nG7V2Q97Qwqef6cpbM6t88zvE0wJt8uUKji4ZfyBif4du8JgpDzzdSi%2BlWYd3YhzNbbfKVH%2F0sfraIHOsRvwNwrVc0V%2Fnmn%2BGlqm1rheswSONIo7BzKo04RLb232aDuWcluEWDMFdNJpzpdgcq96mWrs9KttFyRjUZ%2FhUi8ZQi0R4GXCrfHRTAYOq%2B2TNdECbAEfmA4n9Pb0BDDGDfghLV6h%2FbLrUaMWZCx6U5zCQfymn96h1t5acGgfxYMCS%2FYS7WRPytc759VdSM2KhGVmuGlupbxVz5gVOWffo5rTDQxwiPhcWYHTJlN%2FawmJfHJsJV0WvTBaW9nEPL0QeeUEu3jc7OPW9CbVufHb7Rfg7RQ%2F6Gjz5TBlzfY32lcFTsyRolWjxU3%2FVBb09tcN2EJGBnjZxpl6eFsYOvexTx0ykt0PCQagdR0DPFLPsdj7kDMrdDhpMDjsqQA0W06ULEtlR8unWsjavyK0%2B8CuTN%2BkuMzFrH10Wvqb5j3SYwANq3pyEuf3OScByrY8NVz7EzX%2BYQb5%2FByHmXi99NCHbO6ZQyHnM%2BPWYwinlnFrU6f%2BvI2ruMl35dZ%2BWWSGnEdv0DVxiedxWgqDlov31JoGaaffpBs8OO3LhtYqIixQPFbjq2wPrEcHPLgM40eYtJfduPI6exc%2BkKlxFGOyB44XjDuC4VHBPmCCFH%2FguBAatG%2FSZU1z%2Fj%2FJ0YDIVedDDdPg2NtQXjjjidSW8ISbfOk1SoLSFz04F9BmmMnPVsg9Dvtbbf%2Bz%2FhudrAo9Ys%2Fa6OzksFXxwQ%2FcSIDYVAsYkRjDMcgRv6erm8bBqgABiSF7SwBLkL75mI18fA3qCxgYDrcXZJYCIbS%2BQg9QiROf7PnRBcrnAg0G2ArfRY5gQE69DA4hvUFuXZvCbVbqQGZs7TrKNqBH40DzPqKFqhBKawuCF84zc08QzWVdbl92rAUl%2FbGi6RYzgx27pPzu7LbYLl4G8a5vtVZjuK7SchY0B7FfMvF3uQA%2FY4G%2FjqDGqGshadxalKPmwfUNbDSaatepav%2Bx4zfzQhn6cV2r8t1qz1TfHypR%2BCaAEVhEa36reVmWrAKXjr0JFOSSAQJTti%2BKhNRhaVPTgVI%2BsX%2F0pf8Fn0Zvv%2FbPL9C9L1pEAco%2FGIOV9AHNoh5E18zHcmINA2HmoZWha91ONomoIGvWnlM5USb%2FYSrXZuJDsSFFU9oal%2F45NDUNWlNVsXD%2B8RvuVsl1DY7i9iftU%2FtZpskuIldUFYmXWgMWCwk6sQAaARQoQKBEvCL6OV8UcD3bsde0ubcUG9oH140jsAW6Yh7okoKYZlL2xtp4ba7o8CS3R%2FduPuJLFY6fUexkHpvKj1Nn%2B31oQSjRywNhDdNvlczG4Z2LI73TdsZuCKnSPHNF7DNtOxmeGKZl9z9utufWZIb1FetBPy97bOOVKx69nZYTjmfv7hzBuEd5SweBD9QA2WspaycH9H01R4IXXcnrWKHkkaaVS3jDR%2F%2Bll4S0yGKlVT8EiRqLcZVX6mP2C7tmpbTE1tE%2F5ydEXkHMQ4Q75MDhO6F24ahX2rF%2FyfzuAMnR784wtXAM2E3hvVbCzu1rS9Xy1O7uSL%2Fzw1PxRlBZ%2FTwP00bUw22fQfnye%2Fb5s1NmvpWcrSX6tUNlK%2BrCHlfKSxWVhMWiZOqjMq9chUja87UzhcVXYBWZqhfuGsbRIoDQ40P6k7LDTuuzR7UuMU0nPFvGXsfwyu4UQzQppBmjwdQQlpo9GK2XAR7M2Wj5XNB5yZ3n8uMfW%2BktjiC0yW9bo0BVtvvmEOayXYwXyndHauAcJ0HpHnRLtnzNKnTKI3IY%2Fl4kYFS%2BiYUk6n0nd2eVKroYdrMjKZehZmpwmXfU3%2FWpwmt6HK%2FWKAWZzjlEUaN5zDbG%2BtGNxrjYaVvJuDn2uVtmozVU8dbCdz82O6sukqV5QZ86FFImnlZPOKcSHIFq%2F%2B1AdBG%2FUEKZ28aaadpm11H4ovyjAawjFwoWhtDsJB%2F1YbGDIqlKJ40ZOav8gu1Q%2Bv9UtpaQsDfm84FjlzlmwRQn2LF%2FBZLNmAjc8uug0sItSc2bX9d7gR9EWc3KML3PiBecc%2B6LfUkd5WyqHKPP%2FHDETbor16YGv%2Bt3d6KNtQgY3p%2B2Y8kVRCqtngKNzuid%2FXOmNTpwgKgj69id3uo8asDGcs%2B%2FVu5WjbkDNF%2FJlg2TWyTzwpr53wOKmm6tsWwf2FYScCHzXvfWjxHIR9qyGtIOembCqhaK%2Bv7NYDhaI8dAOtvz2su0yzecbzGa65MlwPIyRmv458OLvCMd1BLubANPxC3YfpMHm7x0JllAwNm4K%2BfM73Qkk6jsLwAr28YC1rvMCRONv4Q0sqEpuXfGbS212hv2LeVMq9wrORW353yq2MeRDxFnc2v0oTtVL9D7nlAlBXotJu4rT%2FzhFkH%2Be%2Fbmcbe1sgbaR4BIqrp65Nwq7RjjbB8FX8fi3xA%2BVE68b9DwmAMsub7oVbmI%2B09Wf85hjYjV5fS1xHdKqT6GRTqF9HhkiRxSIDKXzMM7pBXvzwuG%2BOWTVEBOgctSA2alhhyKvUBizsrW6TO%2FSPoX8n%2Fg3qUfufYGrb05PuoeDayC9iZEzmYc%3D"
-            in captured.out
-        )
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a valid DialogHandler endpoint. Brute forcing Telerik Hash Key" in captured.out
+    assert "Found matching hashkey: [YOUR_ENCRYPTION_KEY_TO_GO_HERE]" in captured.out
+    assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert "Found Telerik Version! [2018.1.117]" in captured.out
+    assert (
+        "gRRgyE4BOGtN%2FLtBxeEeJDuLj%2FUwIG4oBhO5rCDfPjeH10P8Y02mDK3B%2FtsdOIrwILK7XjQiuTlTZMgHckSyb518JPAo6evNlVTPWD5AZX5l4UIUkfdJvq28UHyeBA4eC58PfA6nG7V2Q97Qwqef6cpbM6t88zvE0wJt8uUKji4ZfyBif4du8JgpDzzdSi%2BlWYd3YhzNbbfKVH%2F0sfraIHOsRvwNwrVc0V%2Fnmn%2BGlqm1rheswSONIo7BzKo04RLb232aDuWcluEWDMFdNJpzpdgcq96mWrs9KttFyRjUZ%2FhUi8ZQi0R4GXCrfHRTAYOq%2B2TNdECbAEfmA4n9Pb0BDDGDfghLV6h%2FbLrUaMWZCx6U5zCQfymn96h1t5acGgfxYMCS%2FYS7WRPytc759VdSM2KhGVmuGlupbxVz5gVOWffo5rTDQxwiPhcWYHTJlN%2FawmJfHJsJV0WvTBaW9nEPL0QeeUEu3jc7OPW9CbVufHb7Rfg7RQ%2F6Gjz5TBlzfY32lcFTsyRolWjxU3%2FVBb09tcN2EJGBnjZxpl6eFsYOvexTx0ykt0PCQagdR0DPFLPsdj7kDMrdDhpMDjsqQA0W06ULEtlR8unWsjavyK0%2B8CuTN%2BkuMzFrH10Wvqb5j3SYwANq3pyEuf3OScByrY8NVz7EzX%2BYQb5%2FByHmXi99NCHbO6ZQyHnM%2BPWYwinlnFrU6f%2BvI2ruMl35dZ%2BWWSGnEdv0DVxiedxWgqDlov31JoGaaffpBs8OO3LhtYqIixQPFbjq2wPrEcHPLgM40eYtJfduPI6exc%2BkKlxFGOyB44XjDuC4VHBPmCCFH%2FguBAatG%2FSZU1z%2Fj%2FJ0YDIVedDDdPg2NtQXjjjidSW8ISbfOk1SoLSFz04F9BmmMnPVsg9Dvtbbf%2Bz%2FhudrAo9Ys%2Fa6OzksFXxwQ%2FcSIDYVAsYkRjDMcgRv6erm8bBqgABiSF7SwBLkL75mI18fA3qCxgYDrcXZJYCIbS%2BQg9QiROf7PnRBcrnAg0G2ArfRY5gQE69DA4hvUFuXZvCbVbqQGZs7TrKNqBH40DzPqKFqhBKawuCF84zc08QzWVdbl92rAUl%2FbGi6RYzgx27pPzu7LbYLl4G8a5vtVZjuK7SchY0B7FfMvF3uQA%2FY4G%2FjqDGqGshadxalKPmwfUNbDSaatepav%2Bx4zfzQhn6cV2r8t1qz1TfHypR%2BCaAEVhEa36reVmWrAKXjr0JFOSSAQJTti%2BKhNRhaVPTgVI%2BsX%2F0pf8Fn0Zvv%2FbPL9C9L1pEAco%2FGIOV9AHNoh5E18zHcmINA2HmoZWha91ONomoIGvWnlM5USb%2FYSrXZuJDsSFFU9oal%2F45NDUNWlNVsXD%2B8RvuVsl1DY7i9iftU%2FtZpskuIldUFYmXWgMWCwk6sQAaARQoQKBEvCL6OV8UcD3bsde0ubcUG9oH140jsAW6Yh7okoKYZlL2xtp4ba7o8CS3R%2FduPuJLFY6fUexkHpvKj1Nn%2B31oQSjRywNhDdNvlczG4Z2LI73TdsZuCKnSPHNF7DNtOxmeGKZl9z9utufWZIb1FetBPy97bOOVKx69nZYTjmfv7hzBuEd5SweBD9QA2WspaycH9H01R4IXXcnrWKHkkaaVS3jDR%2F%2Bll4S0yGKlVT8EiRqLcZVX6mP2C7tmpbTE1tE%2F5ydEXkHMQ4Q75MDhO6F24ahX2rF%2FyfzuAMnR784wtXAM2E3hvVbCzu1rS9Xy1O7uSL%2Fzw1PxRlBZ%2FTwP00bUw22fQfnye%2Fb5s1NmvpWcrSX6tUNlK%2BrCHlfKSxWVhMWiZOqjMq9chUja87UzhcVXYBWZqhfuGsbRIoDQ40P6k7LDTuuzR7UuMU0nPFvGXsfwyu4UQzQppBmjwdQQlpo9GK2XAR7M2Wj5XNB5yZ3n8uMfW%2BktjiC0yW9bo0BVtvvmEOayXYwXyndHauAcJ0HpHnRLtnzNKnTKI3IY%2Fl4kYFS%2BiYUk6n0nd2eVKroYdrMjKZehZmpwmXfU3%2FWpwmt6HK%2FWKAWZzjlEUaN5zDbG%2BtGNxrjYaVvJuDn2uVtmozVU8dbCdz82O6sukqV5QZ86FFImnlZPOKcSHIFq%2F%2B1AdBG%2FUEKZ28aaadpm11H4ovyjAawjFwoWhtDsJB%2F1YbGDIqlKJ40ZOav8gu1Q%2Bv9UtpaQsDfm84FjlzlmwRQn2LF%2FBZLNmAjc8uug0sItSc2bX9d7gR9EWc3KML3PiBecc%2B6LfUkd5WyqHKPP%2FHDETbor16YGv%2Bt3d6KNtQgY3p%2B2Y8kVRCqtngKNzuid%2FXOmNTpwgKgj69id3uo8asDGcs%2B%2FVu5WjbkDNF%2FJlg2TWyTzwpr53wOKmm6tsWwf2FYScCHzXvfWjxHIR9qyGtIOembCqhaK%2Bv7NYDhaI8dAOtvz2su0yzecbzGa65MlwPIyRmv458OLvCMd1BLubANPxC3YfpMHm7x0JllAwNm4K%2BfM73Qkk6jsLwAr28YC1rvMCRONv4Q0sqEpuXfGbS212hv2LeVMq9wrORW353yq2MeRDxFnc2v0oTtVL9D7nlAlBXotJu4rT%2FzhFkH%2Be%2Fbmcbe1sgbaR4BIqrp65Nwq7RjjbB8FX8fi3xA%2BVE68b9DwmAMsub7oVbmI%2B09Wf85hjYjV5fS1xHdKqT6GRTqF9HhkiRxSIDKXzMM7pBXvzwuG%2BOWTVEBOgctSA2alhhyKvUBizsrW6TO%2FSPoX8n%2Fg3qUfufYGrb05PuoeDayC9iZEzmYc%3D"
+        in captured.out
+    )
 
 
-def test_misctest_PBKDF1_MS(monkeypatch, capsys, mocker):
+def test_misctest_PBKDF1_MS(monkeypatch, capsys, mocker, bh_mock):
     mocker.patch.object(
         telerik_knownkey,
         "telerik_versions",
@@ -599,40 +618,46 @@ def test_misctest_PBKDF1_MS(monkeypatch, capsys, mocker):
         return_value=iter(["Not_The_Real_HaSh_Key", "YOUR_ENCRYPTION_KEY_TO_GO_HERE", "Y3t_anoth3r_f@k3_key"]),
     )
 
-    with respx.mock:
-        respx.get("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    bh_mock.add_response(
+        url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF1_MS_version_probe_matcher_incorrect(request):
-                return httpx.Response(500)
-            if PBKDF1_MS_encryption_probe_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:Index was outside the bounds of the array.</div>")
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(200, text="Error Message:Length cannot be less than zero")
-            if PBKDF1_MS_found_key_matcher_negative(request):
-                return httpx.Response(200, text="<div>Error Message:The hash is not valid!</div>")
-            if PBKDF1_MS_found_key_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:The input data is not a complete block.</div>")
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF1_MS_version_probe_matcher_incorrect(request):
+            return MockResponse(status_code=500)
+        if PBKDF1_MS_encryption_probe_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Index was outside the bounds of the array.</div>"
+            )
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(status_code=200, text="Error Message:Length cannot be less than zero")
+        if PBKDF1_MS_found_key_matcher_negative(request):
+            return MockResponse(status_code=200, text="<div>Error Message:The hash is not valid!</div>")
+        if PBKDF1_MS_found_key_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:The input data is not a complete block.</div>"
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a valid DialogHandler endpoint. Brute forcing Telerik Hash Key" in captured.out
-        assert "Found Telerik Version!" not in captured.out
-        assert "SUCCESS! Found matching hashkey: [YOUR_ENCRYPTION_KEY_TO_GO_HERE]" in captured.out
-        assert "Now checking for known Telerik Encryption Keys..."
-        assert "Could not identify encryption key." in captured.out
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a valid DialogHandler endpoint. Brute forcing Telerik Hash Key" in captured.out
+    assert "Found Telerik Version!" not in captured.out
+    assert "SUCCESS! Found matching hashkey: [YOUR_ENCRYPTION_KEY_TO_GO_HERE]" in captured.out
+    assert "Now checking for known Telerik Encryption Keys..."
+    assert "Could not identify encryption key." in captured.out
 
 
-def test_nomatch_PBKDF1_MS(monkeypatch, capsys, mocker):
+def test_nomatch_PBKDF1_MS(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(
             ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
@@ -644,25 +669,65 @@ def test_nomatch_PBKDF1_MS(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        respx.get("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
+    bh_mock.add_response(
+        url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
+
+    def _post_dispatcher(request):
+        if pre2017_matcher_probe(request):
+            return MockResponse(
+                status_code=200,
+                text="<div style='color:red'>Cannot deserialize dialog parameters. Please refresh the editor page.</div><div>Error Message:The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters. </div>",
+            )
+        if pre2017_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text="<div style='color:red'>Cannot deserialize dialog parameters. Please refresh the editor page.</div><div>Error Message:Invalid length for a Base-64 char array or string.</div>",
+            )
+        return MockResponse(status_code=200)
+
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target appears to be a pre-2017 version without hash key (CVE-2017-9248)" in captured.out
+
+
+def test_badoutput_PBKDF1_MS(monkeypatch, capsys, mocker, bh_mock):
+    def generate_keylist_enc(include_machinekeys):
+        return iter(
+            ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
+        )
+
+    def generate_keylist_hash(include_machinekeys):
+        return iter(["Not_The_Real_HaSh_Key", "YOUR_ENCRYPTION_KEY_TO_GO_HERE", "Y3t_anoth3r_f@k3_key"])
+
+    mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
+    mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
+
+    with patch("sys.exit") as exit_mock:
+        bh_mock.add_response(
+            url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+            method="GET",
+            status_code=200,
+            text=partial_dialog_page,
         )
 
         def _post_dispatcher(request):
             if pre2017_matcher_probe(request):
-                return httpx.Response(
-                    200,
-                    text="<div style='color:red'>Cannot deserialize dialog parameters. Please refresh the editor page.</div><div>Error Message:The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters. </div>",
-                )
+                return MockResponse(status_code=200, text="garbage data")
             if pre2017_matcher(request):
-                return httpx.Response(
-                    200,
-                    text="<div style='color:red'>Cannot deserialize dialog parameters. Please refresh the editor page.</div><div>Error Message:Invalid length for a Base-64 char array or string.</div>",
-                )
-            return httpx.Response(200)
+                return MockResponse(status_code=200, text="garbage data")
+            return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
+        bh_mock.add_callback(_post_dispatcher, url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
         monkeypatch.setattr(
             "sys.argv",
             ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
@@ -670,10 +735,11 @@ def test_nomatch_PBKDF1_MS(monkeypatch, capsys, mocker):
         telerik_knownkey.main()
         captured = capsys.readouterr()
         print(captured.out)
-        assert "Target appears to be a pre-2017 version without hash key (CVE-2017-9248)" in captured.out
+        assert "Unexpected response encountered: [garbage data] aborting." in captured.out
+        assert exit_mock.called
 
 
-def test_badoutput_PBKDF1_MS(monkeypatch, capsys, mocker):
+def test_fullrun_asyncupload_earlydetection(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(
             ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
@@ -685,34 +751,41 @@ def test_badoutput_PBKDF1_MS(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        with patch("sys.exit") as exit_mock:
-            respx.get("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-                status_code=200, text=partial_dialog_page
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
+
+    def _post_dispatcher(request):
+        if asyncupload_early_result_matcher_incorrect(request):
+            return MockResponse(status_code=500)
+        if asyncupload_early_result_matcher(request):
+            return MockResponse(
+                status_code=500,
+                text="<title>telerik</title><b> Exception Details: </b>System.IO.FileLoadException: Could not load file or assembly 'Telerik.Web.UI, Version=2022.3.1109, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)<br><br>",
             )
+        return MockResponse(status_code=200)
 
-            def _post_dispatcher(request):
-                if pre2017_matcher_probe(request):
-                    return httpx.Response(200, text="garbage data")
-                if pre2017_matcher(request):
-                    return httpx.Response(200, text="garbage data")
-                return httpx.Response(200)
-
-            respx.post("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(
-                side_effect=_post_dispatcher
-            )
-            monkeypatch.setattr(
-                "sys.argv",
-                ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
-            )
-            telerik_knownkey.main()
-            captured = capsys.readouterr()
-            print(captured.out)
-            assert "Unexpected response encountered: [garbage data] aborting." in captured.out
-            assert exit_mock.called
+    bh_mock.add_callback(
+        _post_dispatcher, url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU"
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert (
+        "Detected early signs that target is likely vulnerable! Continuing to find vulnerable version..."
+        in captured.out
+    )
 
 
-def test_fullrun_asyncupload_earlydetection(monkeypatch, capsys, mocker):
+def test_fullrun_asyncupload_success(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(
             ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
@@ -724,81 +797,41 @@ def test_fullrun_asyncupload_earlydetection(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
 
-        def _post_dispatcher(request):
-            if asyncupload_early_result_matcher_incorrect(request):
-                return httpx.Response(500)
-            if asyncupload_early_result_matcher(request):
-                return httpx.Response(
-                    500,
-                    text="<title>telerik</title><b> Exception Details: </b>System.IO.FileLoadException: Could not load file or assembly 'Telerik.Web.UI, Version=2022.3.1109, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)<br><br>",
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if asyncupload_found_key_matcher_incorrect(request):
+            return MockResponse(status_code=500)
+        if asyncupload_found_key_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text='{"fileInfo":{"FileName":"1c72ebb0","ContentType":"text/html","ContentLength":8,"DateJson":"2020-01-02T08:02:01.067Z","Index":0}, "metaData":"a+pkVM70XskLLvpXsOGH+RUEWaNgrvi2EGIZcUrVQ4rr7hIwpIcHtxyJsGCQYWy5tgSKmK58kIk/HpDDs9Gh2qnaFi3m+pe0kb4xb8s6zIkxQYrYGrfj7EesKwvuY6HUn+y3GwesijRrVsPpt0/N5FYxu4ptrsmjWfIM65XOe8b47kLO/Rpx/4/lfJyT9ZFsFuvSZmJzWDdoV40wu5ROK9DVnU26ztRRCwpnqqxmeKvdSGpYwd/d1gisJy0i5UVNFuvRT2XC32eDiw3Kn9GOrRldOHtq5WAQWu2YzVmxr/NOmvjg3NpRLtbxU+h9D0u0K/B3kRYliO+XlCpG+l/QMLh2nAjQehNvaCG3wJ4dkW9JHHeNzbPyd+tNrlSBj6/Z+b/Ld2HCk3XydTRHuUyzqk8bC6rEHGdclNPmTIS2X0IZaI0wTctsnPHxiruwdWVNjepnaSv5IHHYFH3WhCzKy6cLPES0cAuVgxycs+49nuj7kL/JzqT6iJm0YZd/Qjo4" }',
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert (
-            "Detected early signs that target is likely vulnerable! Continuing to find vulnerable version..."
-            in captured.out
-        )
-
-
-def test_fullrun_asyncupload_success(monkeypatch, capsys, mocker):
-    def generate_keylist_enc(include_machinekeys):
-        return iter(
-            ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
-        )
-
-    def generate_keylist_hash(include_machinekeys):
-        return iter(["Not_The_Real_HaSh_Key", "YOUR_ENCRYPTION_KEY_TO_GO_HERE", "Y3t_anoth3r_f@k3_key"])
-
-    mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
-    mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
-
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
-
-        def _post_dispatcher(request):
-            if asyncupload_found_key_matcher_incorrect(request):
-                return httpx.Response(500)
-            if asyncupload_found_key_matcher(request):
-                return httpx.Response(
-                    200,
-                    text='{"fileInfo":{"FileName":"1c72ebb0","ContentType":"text/html","ContentLength":8,"DateJson":"2020-01-02T08:02:01.067Z","Index":0}, "metaData":"a+pkVM70XskLLvpXsOGH+RUEWaNgrvi2EGIZcUrVQ4rr7hIwpIcHtxyJsGCQYWy5tgSKmK58kIk/HpDDs9Gh2qnaFi3m+pe0kb4xb8s6zIkxQYrYGrfj7EesKwvuY6HUn+y3GwesijRrVsPpt0/N5FYxu4ptrsmjWfIM65XOe8b47kLO/Rpx/4/lfJyT9ZFsFuvSZmJzWDdoV40wu5ROK9DVnU26ztRRCwpnqqxmeKvdSGpYwd/d1gisJy0i5UVNFuvRT2XC32eDiw3Kn9GOrRldOHtq5WAQWu2YzVmxr/NOmvjg3NpRLtbxU+h9D0u0K/B3kRYliO+XlCpG+l/QMLh2nAjQehNvaCG3wJ4dkW9JHHeNzbPyd+tNrlSBj6/Z+b/Ld2HCk3XydTRHuUyzqk8bC6rEHGdclNPmTIS2X0IZaI0wTctsnPHxiruwdWVNjepnaSv5IHHYFH3WhCzKy6cLPES0cAuVgxycs+49nuj7kL/JzqT6iJm0YZd/Qjo4" }',
-                )
-            return httpx.Response(200)
-
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert (
-            "TARGET VULNERABLE! Version: [2022.3.913] Encryption Key: [d2a312d9-7af4-43de-be5a-ae717b46cea6] Hash Key: [YOUR_ENCRYPTION_KEY_TO_GO_HERE] Derive Algo: [PBKDF2]"
-            in captured.out
-        )
+    bh_mock.add_callback(
+        _post_dispatcher, url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU"
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert (
+        "TARGET VULNERABLE! Version: [2022.3.913] Encryption Key: [d2a312d9-7af4-43de-be5a-ae717b46cea6] Hash Key: [YOUR_ENCRYPTION_KEY_TO_GO_HERE] Derive Algo: [PBKDF2]"
+        in captured.out
+    )
 
 
-def test_fullrun_asyncupload_success_version_customkeys(monkeypatch, capsys, mocker):
+def test_fullrun_asyncupload_success_version_customkeys(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(["Not_The_Real_Encryption_Key", "another_fake_encryption_key"])
 
@@ -808,171 +841,185 @@ def test_fullrun_asyncupload_success_version_customkeys(monkeypatch, capsys, moc
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
 
-        def _post_dispatcher(request):
-            if asyncupload_found_key_matcher_incorrect(request):
-                return httpx.Response(500)
-            if asyncupload_found_key_matcher(request):
-                return httpx.Response(
-                    200,
-                    text='{"fileInfo":{"FileName":"1c72ebb0","ContentType":"text/html","ContentLength":8,"DateJson":"2020-01-02T08:02:01.067Z","Index":0}, "metaData":"a+pkVM70XskLLvpXsOGH+RUEWaNgrvi2EGIZcUrVQ4rr7hIwpIcHtxyJsGCQYWy5tgSKmK58kIk/HpDDs9Gh2qnaFi3m+pe0kb4xb8s6zIkxQYrYGrfj7EesKwvuY6HUn+y3GwesijRrVsPpt0/N5FYxu4ptrsmjWfIM65XOe8b47kLO/Rpx/4/lfJyT9ZFsFuvSZmJzWDdoV40wu5ROK9DVnU26ztRRCwpnqqxmeKvdSGpYwd/d1gisJy0i5UVNFuvRT2XC32eDiw3Kn9GOrRldOHtq5WAQWu2YzVmxr/NOmvjg3NpRLtbxU+h9D0u0K/B3kRYliO+XlCpG+l/QMLh2nAjQehNvaCG3wJ4dkW9JHHeNzbPyd+tNrlSBj6/Z+b/Ld2HCk3XydTRHuUyzqk8bC6rEHGdclNPmTIS2X0IZaI0wTctsnPHxiruwdWVNjepnaSv5IHHYFH3WhCzKy6cLPES0cAuVgxycs+49nuj7kL/JzqT6iJm0YZd/Qjo4" }',
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if asyncupload_found_key_matcher_incorrect(request):
+            return MockResponse(status_code=500)
+        if asyncupload_found_key_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text='{"fileInfo":{"FileName":"1c72ebb0","ContentType":"text/html","ContentLength":8,"DateJson":"2020-01-02T08:02:01.067Z","Index":0}, "metaData":"a+pkVM70XskLLvpXsOGH+RUEWaNgrvi2EGIZcUrVQ4rr7hIwpIcHtxyJsGCQYWy5tgSKmK58kIk/HpDDs9Gh2qnaFi3m+pe0kb4xb8s6zIkxQYrYGrfj7EesKwvuY6HUn+y3GwesijRrVsPpt0/N5FYxu4ptrsmjWfIM65XOe8b47kLO/Rpx/4/lfJyT9ZFsFuvSZmJzWDdoV40wu5ROK9DVnU26ztRRCwpnqqxmeKvdSGpYwd/d1gisJy0i5UVNFuvRT2XC32eDiw3Kn9GOrRldOHtq5WAQWu2YzVmxr/NOmvjg3NpRLtbxU+h9D0u0K/B3kRYliO+XlCpG+l/QMLh2nAjQehNvaCG3wJ4dkW9JHHeNzbPyd+tNrlSBj6/Z+b/Ld2HCk3XydTRHuUyzqk8bC6rEHGdclNPmTIS2X0IZaI0wTctsnPHxiruwdWVNjepnaSv5IHHYFH3WhCzKy6cLPES0cAuVgxycs+49nuj7kL/JzqT6iJm0YZd/Qjo4" }',
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd",
-                "--force",
-                "--debug",
-                "--version",
-                "2022.3.913",
-                "--custom-keys",
-                "d2a312d9-7af4-43de-be5a-ae717b46cea6,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
-            ],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert (
-            "TARGET VULNERABLE! Version: [2022.3.913] Encryption Key: [d2a312d9-7af4-43de-be5a-ae717b46cea6] Hash Key: [YOUR_ENCRYPTION_KEY_TO_GO_HERE] Derive Algo: [PBKDF2]"
-            in captured.out
-        )
-
-
-def test_fullrun_asyncupload_PBKDF1_MS(monkeypatch, capsys, mocker):
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
-
-        def _post_dispatcher(request):
-            if asyncupload_found_key_matcher_PBKDF1_MS_incorrect(request):
-                return httpx.Response(500)
-            if asyncupload_found_key_matcher_PBKDF1_MS(request):
-                return httpx.Response(
-                    200,
-                    text='{"fileInfo":{"FileName":"1c72ebb0","ContentType":"text/html","ContentLength":8,"DateJson":"2020-01-02T08:02:01.067Z","Index":0}, "metaData":"a+pkVM70XskLLvpXsOGH+RUEWaNgrvi2EGIZcUrVQ4rr7hIwpIcHtxyJsGCQYWy5tgSKmK58kIk/HpDDs9Gh2qnaFi3m+pe0kb4xb8s6zIkxQYrYGrfj7EesKwvuY6HUn+y3GwesijRrVsPpt0/N5FYxu4ptrsmjWfIM65XOe8b47kLO/Rpx/4/lfJyT9ZFsFuvSZmJzWDdoV40wu5ROK9DVnU26ztRRCwpnqqxmeKvdSGpYwd/d1gisJy0i5UVNFuvRT2XC32eDiw3Kn9GOrRldOHtq5WAQWu2YzVmxr/NOmvjg3NpRLtbxU+h9D0u0K/B3kRYliO+XlCpG+l/QMLh2nAjQehNvaCG3wJ4dkW9JHHeNzbPyd+tNrlSBj6/Z+b/Ld2HCk3XydTRHuUyzqk8bC6rEHGdclNPmTIS2X0IZaI0wTctsnPHxiruwdWVNjepnaSv5IHHYFH3WhCzKy6cLPES0cAuVgxycs+49nuj7kL/JzqT6iJm0YZd/Qjo4" }',
-                )
-            return httpx.Response(200)
-
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert (
-            "TARGET VULNERABLE! Version: [2014.3.1024] Encryption Key: [d2a312d9-7af4-43de-be5a-ae717b46cea6] Derive Algo: [PBKDF1_MS]"
-            in captured.out
-        )
+    bh_mock.add_callback(
+        _post_dispatcher, url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU"
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd",
+            "--force",
+            "--debug",
+            "--version",
+            "2022.3.913",
+            "--custom-keys",
+            "d2a312d9-7af4-43de-be5a-ae717b46cea6,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
+        ],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert (
+        "TARGET VULNERABLE! Version: [2022.3.913] Encryption Key: [d2a312d9-7af4-43de-be5a-ae717b46cea6] Hash Key: [YOUR_ENCRYPTION_KEY_TO_GO_HERE] Derive Algo: [PBKDF2]"
+        in captured.out
+    )
 
 
-def test_verbose_error_parsing_PBKDF1_MS(monkeypatch, capsys, mocker):
+def test_fullrun_asyncupload_PBKDF1_MS(monkeypatch, capsys, mocker, bh_mock):
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
+
+    def _post_dispatcher(request):
+        if asyncupload_found_key_matcher_PBKDF1_MS_incorrect(request):
+            return MockResponse(status_code=500)
+        if asyncupload_found_key_matcher_PBKDF1_MS(request):
+            return MockResponse(
+                status_code=200,
+                text='{"fileInfo":{"FileName":"1c72ebb0","ContentType":"text/html","ContentLength":8,"DateJson":"2020-01-02T08:02:01.067Z","Index":0}, "metaData":"a+pkVM70XskLLvpXsOGH+RUEWaNgrvi2EGIZcUrVQ4rr7hIwpIcHtxyJsGCQYWy5tgSKmK58kIk/HpDDs9Gh2qnaFi3m+pe0kb4xb8s6zIkxQYrYGrfj7EesKwvuY6HUn+y3GwesijRrVsPpt0/N5FYxu4ptrsmjWfIM65XOe8b47kLO/Rpx/4/lfJyT9ZFsFuvSZmJzWDdoV40wu5ROK9DVnU26ztRRCwpnqqxmeKvdSGpYwd/d1gisJy0i5UVNFuvRT2XC32eDiw3Kn9GOrRldOHtq5WAQWu2YzVmxr/NOmvjg3NpRLtbxU+h9D0u0K/B3kRYliO+XlCpG+l/QMLh2nAjQehNvaCG3wJ4dkW9JHHeNzbPyd+tNrlSBj6/Z+b/Ld2HCk3XydTRHuUyzqk8bC6rEHGdclNPmTIS2X0IZaI0wTctsnPHxiruwdWVNjepnaSv5IHHYFH3WhCzKy6cLPES0cAuVgxycs+49nuj7kL/JzqT6iJm0YZd/Qjo4" }',
+            )
+        return MockResponse(status_code=200)
+
+    bh_mock.add_callback(
+        _post_dispatcher, url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU"
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert (
+        "TARGET VULNERABLE! Version: [2014.3.1024] Encryption Key: [d2a312d9-7af4-43de-be5a-ae717b46cea6] Derive Algo: [PBKDF1_MS]"
+        in captured.out
+    )
+
+
+def test_verbose_error_parsing_PBKDF1_MS(monkeypatch, capsys, mocker, bh_mock):
     mocker.patch.object(
         telerik_knownkey.AsyncUpload,
         "solve_key",
         lambda x: None,
     )
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
 
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text="<b> Exception Details: </b>System.Security.Cryptography.CryptographicException: Padding is invalid and cannot be removed.<br><br>",
-        )
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="POST",
+        status_code=200,
+        text="<b> Exception Details: </b>System.Security.Cryptography.CryptographicException: Padding is invalid and cannot be removed.<br><br>",
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Verbose Errors are enabled!" in captured.out
-        assert (
-            "Version is <= 2019 (Either Vulnerable, or Encrypt-Then-Mac with separate failure Message)" in captured.out
-        )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Verbose Errors are enabled!" in captured.out
+    assert "Version is <= 2019 (Either Vulnerable, or Encrypt-Then-Mac with separate failure Message)" in captured.out
 
 
-def test_verbose_error_parsing_notdetermined_PBKDF1_MS(monkeypatch, capsys, mocker):
+def test_verbose_error_parsing_notdetermined_PBKDF1_MS(monkeypatch, capsys, mocker, bh_mock):
     mocker.patch.object(
         telerik_knownkey.AsyncUpload,
         "solve_key",
         lambda x: None,
     )
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
 
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200, text="<b> Exception Details: garbage"
-        )
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="POST",
+        status_code=200,
+        text="<b> Exception Details: garbage",
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Verbose Errors are enabled!" in captured.out
-        assert "Version could not be determined" in captured.out
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Verbose Errors are enabled!" in captured.out
+    assert "Version could not be determined" in captured.out
 
 
-def test_verbose_error_parsing_PBKDF2(monkeypatch, capsys, mocker):
+def test_verbose_error_parsing_PBKDF2(monkeypatch, capsys, mocker, bh_mock):
     mocker.patch.object(
         telerik_knownkey.AsyncUpload,
         "solve_key",
         lambda x: None,
     )
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
 
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='<b> Exception Details: </b>System.Security.Cryptography.CryptographicException: The cryptographic operation has failed!<br><br><b>Stack Trace:</b> <br><br><table width=100% bgcolor="#ffffcc"><tr><td>code><pre>[CryptographicException: The cryptographic operation has failed!]Telerik.Web.UI.CryptoExceptionThrower.ThrowGenericCryptoException() +62',
-        )
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="POST",
+        status_code=200,
+        text='<b> Exception Details: </b>System.Security.Cryptography.CryptographicException: The cryptographic operation has failed!<br><br><b>Stack Trace:</b> <br><br><table width=100% bgcolor="#ffffcc"><tr><td>code><pre>[CryptographicException: The cryptographic operation has failed!]Telerik.Web.UI.CryptoExceptionThrower.ThrowGenericCryptoException() +62',
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Verbose Errors are enabled!" in captured.out
-        assert "Version is Post-2020 (Encrypt-Then-Mac Enabled, with Generic Crypto Failure Message)" in captured.out
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Verbose Errors are enabled!" in captured.out
+    assert "Version is Post-2020 (Encrypt-Then-Mac Enabled, with Generic Crypto Failure Message)" in captured.out
 
 
-def test_fullrun_PBKDF2_onlyhashkeyfound(monkeypatch, capsys, mocker):
+def test_fullrun_PBKDF2_onlyhashkeyfound(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(
             ["Not_The_Real_Encryption_Key", "d2a312d9-7af4-43de-be5a-ae717b46cea6", "another_fake_encryption_key"]
@@ -984,44 +1031,46 @@ def test_fullrun_PBKDF2_onlyhashkeyfound(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF2_version_probe_matcher_incorrect(request):
-                return httpx.Response(
-                    200,
-                    text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF2_version_probe_matcher(request):
-                return httpx.Response(200, text="DoesntMatter")
-            if PBKDF2_found_key_matcher_negative(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
-                )
-            if PBKDF2_found_key_matcher(request):
-                return httpx.Response(
-                    200,
-                    text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF2_version_probe_matcher_incorrect(request):
+            return MockResponse(
+                status_code=200,
+                text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF2_version_probe_matcher(request):
+            return MockResponse(status_code=200, text="DoesntMatter")
+        if PBKDF2_found_key_matcher_negative(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
+            )
+        if PBKDF2_found_key_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a newer version of Telerik UI" in captured.out
-        assert "Did not find hashkey / encryption key. Exiting." in captured.out
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a newer version of Telerik UI" in captured.out
+    assert "Did not find hashkey / encryption key. Exiting." in captured.out
 
 
-def test_fullrun_PBKDF1_MS_customkeys(monkeypatch, capsys, mocker):
+def test_fullrun_PBKDF1_MS_customkeys(monkeypatch, capsys, mocker, bh_mock):
     mocker.patch.object(
         Telerik_EncryptionKey,
         "prepare_keylist",
@@ -1033,54 +1082,60 @@ def test_fullrun_PBKDF1_MS_customkeys(monkeypatch, capsys, mocker):
         return_value=iter(["Not_The_Real_HaSh_Key", "Y3t_anoth3r_f@k3_key"]),
     )
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF1_MS_version_probe_matcher_incorrect(request):
-                return httpx.Response(
-                    200,
-                    text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF1_MS_encryption_probe_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:Index was outside the bounds of the array.</div>")
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(200, text="Error Message:Length cannot be less than zero")
-            if PBKDF1_MS_found_key_matcher_negative(request):
-                return httpx.Response(200, text="<div>Error Message:The hash is not valid!</div>")
-            if PBKDF1_MS_found_key_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:The input data is not a complete block.</div>")
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF1_MS_version_probe_matcher_incorrect(request):
+            return MockResponse(
+                status_code=200,
+                text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF1_MS_encryption_probe_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Index was outside the bounds of the array.</div>"
+            )
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(status_code=200, text="Error Message:Length cannot be less than zero")
+        if PBKDF1_MS_found_key_matcher_negative(request):
+            return MockResponse(status_code=200, text="<div>Error Message:The hash is not valid!</div>")
+        if PBKDF1_MS_found_key_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:The input data is not a complete block.</div>"
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
-                "--debug",
-                "--custom-keys",
-                "d2a312d9-7af4-43de-be5a-ae717b46cea6,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
-            ],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a valid DialogHandler endpoint. Brute forcing Telerik Hash Key" in captured.out
-        assert "Found matching hashkey: [YOUR_ENCRYPTION_KEY_TO_GO_HERE]" in captured.out
-        assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert "Found Telerik Version! [2018.1.117]" in captured.out
-        assert (
-            "gRRgyE4BOGtN%2FLtBxeEeJDuLj%2FUwIG4oBhO5rCDfPjeH10P8Y02mDK3B%2FtsdOIrwILK7XjQiuTlTZMgHckSyb518JPAo6evNlVTPWD5AZX5l4UIUkfdJvq28UHyeBA4eC58PfA6nG7V2Q97Qwqef6cpbM6t88zvE0wJt8uUKji4ZfyBif4du8JgpDzzdSi%2BlWYd3YhzNbbfKVH%2F0sfraIHOsRvwNwrVc0V%2Fnmn%2BGlqm1rheswSONIo7BzKo04RLb232aDuWcluEWDMFdNJpzpdgcq96mWrs9KttFyRjUZ%2FhUi8ZQi0R4GXCrfHRTAYOq%2B2TNdECbAEfmA4n9Pb0BDDGDfghLV6h%2FbLrUaMWZCx6U5zCQfymn96h1t5acGgfxYMCS%2FYS7WRPytc759VdSM2KhGVmuGlupbxVz5gVOWffo5rTDQxwiPhcWYHTJlN%2FawmJfHJsJV0WvTBaW9nEPL0QeeUEu3jc7OPW9CbVufHb7Rfg7RQ%2F6Gjz5TBlzfY32lcFTsyRolWjxU3%2FVBb09tcN2EJGBnjZxpl6eFsYOvexTx0ykt0PCQagdR0DPFLPsdj7kDMrdDhpMDjsqQA0W06ULEtlR8unWsjavyK0%2B8CuTN%2BkuMzFrH10Wvqb5j3SYwANq3pyEuf3OScByrY8NVz7EzX%2BYQb5%2FByHmXi99NCHbO6ZQyHnM%2BPWYwinlnFrU6f%2BvI2ruMl35dZ%2BWWSGnEdv0DVxiedxWgqDlov31JoGaaffpBs8OO3LhtYqIixQPFbjq2wPrEcHPLgM40eYtJfduPI6exc%2BkKlxFGOyB44XjDuC4VHBPmCCFH%2FguBAatG%2FSZU1z%2Fj%2FJ0YDIVedDDdPg2NtQXjjjidSW8ISbfOk1SoLSFz04F9BmmMnPVsg9Dvtbbf%2Bz%2FhudrAo9Ys%2Fa6OzksFXxwQ%2FcSIDYVAsYkRjDMcgRv6erm8bBqgABiSF7SwBLkL75mI18fA3qCxgYDrcXZJYCIbS%2BQg9QiROf7PnRBcrnAg0G2ArfRY5gQE69DA4hvUFuXZvCbVbqQGZs7TrKNqBH40DzPqKFqhBKawuCF84zc08QzWVdbl92rAUl%2FbGi6RYzgx27pPzu7LbYLl4G8a5vtVZjuK7SchY0B7FfMvF3uQA%2FY4G%2FjqDGqGshadxalKPmwfUNbDSaatepav%2Bx4zfzQhn6cV2r8t1qz1TfHypR%2BCaAEVhEa36reVmWrAKXjr0JFOSSAQJTti%2BKhNRhaVPTgVI%2BsX%2F0pf8Fn0Zvv%2FbPL9C9L1pEAco%2FGIOV9AHNoh5E18zHcmINA2HmoZWha91ONomoIGvWnlM5USb%2FYSrXZuJDsSFFU9oal%2F45NDUNWlNVsXD%2B8RvuVsl1DY7i9iftU%2FtZpskuIldUFYmXWgMWCwk6sQAaARQoQKBEvCL6OV8UcD3bsde0ubcUG9oH140jsAW6Yh7okoKYZlL2xtp4ba7o8CS3R%2FduPuJLFY6fUexkHpvKj1Nn%2B31oQSjRywNhDdNvlczG4Z2LI73TdsZuCKnSPHNF7DNtOxmeGKZl9z9utufWZIb1FetBPy97bOOVKx69nZYTjmfv7hzBuEd5SweBD9QA2WspaycH9H01R4IXXcnrWKHkkaaVS3jDR%2F%2Bll4S0yGKlVT8EiRqLcZVX6mP2C7tmpbTE1tE%2F5ydEXkHMQ4Q75MDhO6F24ahX2rF%2FyfzuAMnR784wtXAM2E3hvVbCzu1rS9Xy1O7uSL%2Fzw1PxRlBZ%2FTwP00bUw22fQfnye%2Fb5s1NmvpWcrSX6tUNlK%2BrCHlfKSxWVhMWiZOqjMq9chUja87UzhcVXYBWZqhfuGsbRIoDQ40P6k7LDTuuzR7UuMU0nPFvGXsfwyu4UQzQppBmjwdQQlpo9GK2XAR7M2Wj5XNB5yZ3n8uMfW%2BktjiC0yW9bo0BVtvvmEOayXYwXyndHauAcJ0HpHnRLtnzNKnTKI3IY%2Fl4kYFS%2BiYUk6n0nd2eVKroYdrMjKZehZmpwmXfU3%2FWpwmt6HK%2FWKAWZzjlEUaN5zDbG%2BtGNxrjYaVvJuDn2uVtmozVU8dbCdz82O6sukqV5QZ86FFImnlZPOKcSHIFq%2F%2B1AdBG%2FUEKZ28aaadpm11H4ovyjAawjFwoWhtDsJB%2F1YbGDIqlKJ40ZOav8gu1Q%2Bv9UtpaQsDfm84FjlzlmwRQn2LF%2FBZLNmAjc8uug0sItSc2bX9d7gR9EWc3KML3PiBecc%2B6LfUkd5WyqHKPP%2FHDETbor16YGv%2Bt3d6KNtQgY3p%2B2Y8kVRCqtngKNzuid%2FXOmNTpwgKgj69id3uo8asDGcs%2B%2FVu5WjbkDNF%2FJlg2TWyTzwpr53wOKmm6tsWwf2FYScCHzXvfWjxHIR9qyGtIOembCqhaK%2Bv7NYDhaI8dAOtvz2su0yzecbzGa65MlwPIyRmv458OLvCMd1BLubANPxC3YfpMHm7x0JllAwNm4K%2BfM73Qkk6jsLwAr28YC1rvMCRONv4Q0sqEpuXfGbS212hv2LeVMq9wrORW353yq2MeRDxFnc2v0oTtVL9D7nlAlBXotJu4rT%2FzhFkH%2Be%2Fbmcbe1sgbaR4BIqrp65Nwq7RjjbB8FX8fi3xA%2BVE68b9DwmAMsub7oVbmI%2B09Wf85hjYjV5fS1xHdKqT6GRTqF9HhkiRxSIDKXzMM7pBXvzwuG%2BOWTVEBOgctSA2alhhyKvUBizsrW6TO%2FSPoX8n%2Fg3qUfufYGrb05PuoeDayC9iZEzmYc%3D"
-            in captured.out
-        )
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+            "--debug",
+            "--custom-keys",
+            "d2a312d9-7af4-43de-be5a-ae717b46cea6,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
+        ],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a valid DialogHandler endpoint. Brute forcing Telerik Hash Key" in captured.out
+    assert "Found matching hashkey: [YOUR_ENCRYPTION_KEY_TO_GO_HERE]" in captured.out
+    assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert "Found Telerik Version! [2018.1.117]" in captured.out
+    assert (
+        "gRRgyE4BOGtN%2FLtBxeEeJDuLj%2FUwIG4oBhO5rCDfPjeH10P8Y02mDK3B%2FtsdOIrwILK7XjQiuTlTZMgHckSyb518JPAo6evNlVTPWD5AZX5l4UIUkfdJvq28UHyeBA4eC58PfA6nG7V2Q97Qwqef6cpbM6t88zvE0wJt8uUKji4ZfyBif4du8JgpDzzdSi%2BlWYd3YhzNbbfKVH%2F0sfraIHOsRvwNwrVc0V%2Fnmn%2BGlqm1rheswSONIo7BzKo04RLb232aDuWcluEWDMFdNJpzpdgcq96mWrs9KttFyRjUZ%2FhUi8ZQi0R4GXCrfHRTAYOq%2B2TNdECbAEfmA4n9Pb0BDDGDfghLV6h%2FbLrUaMWZCx6U5zCQfymn96h1t5acGgfxYMCS%2FYS7WRPytc759VdSM2KhGVmuGlupbxVz5gVOWffo5rTDQxwiPhcWYHTJlN%2FawmJfHJsJV0WvTBaW9nEPL0QeeUEu3jc7OPW9CbVufHb7Rfg7RQ%2F6Gjz5TBlzfY32lcFTsyRolWjxU3%2FVBb09tcN2EJGBnjZxpl6eFsYOvexTx0ykt0PCQagdR0DPFLPsdj7kDMrdDhpMDjsqQA0W06ULEtlR8unWsjavyK0%2B8CuTN%2BkuMzFrH10Wvqb5j3SYwANq3pyEuf3OScByrY8NVz7EzX%2BYQb5%2FByHmXi99NCHbO6ZQyHnM%2BPWYwinlnFrU6f%2BvI2ruMl35dZ%2BWWSGnEdv0DVxiedxWgqDlov31JoGaaffpBs8OO3LhtYqIixQPFbjq2wPrEcHPLgM40eYtJfduPI6exc%2BkKlxFGOyB44XjDuC4VHBPmCCFH%2FguBAatG%2FSZU1z%2Fj%2FJ0YDIVedDDdPg2NtQXjjjidSW8ISbfOk1SoLSFz04F9BmmMnPVsg9Dvtbbf%2Bz%2FhudrAo9Ys%2Fa6OzksFXxwQ%2FcSIDYVAsYkRjDMcgRv6erm8bBqgABiSF7SwBLkL75mI18fA3qCxgYDrcXZJYCIbS%2BQg9QiROf7PnRBcrnAg0G2ArfRY5gQE69DA4hvUFuXZvCbVbqQGZs7TrKNqBH40DzPqKFqhBKawuCF84zc08QzWVdbl92rAUl%2FbGi6RYzgx27pPzu7LbYLl4G8a5vtVZjuK7SchY0B7FfMvF3uQA%2FY4G%2FjqDGqGshadxalKPmwfUNbDSaatepav%2Bx4zfzQhn6cV2r8t1qz1TfHypR%2BCaAEVhEa36reVmWrAKXjr0JFOSSAQJTti%2BKhNRhaVPTgVI%2BsX%2F0pf8Fn0Zvv%2FbPL9C9L1pEAco%2FGIOV9AHNoh5E18zHcmINA2HmoZWha91ONomoIGvWnlM5USb%2FYSrXZuJDsSFFU9oal%2F45NDUNWlNVsXD%2B8RvuVsl1DY7i9iftU%2FtZpskuIldUFYmXWgMWCwk6sQAaARQoQKBEvCL6OV8UcD3bsde0ubcUG9oH140jsAW6Yh7okoKYZlL2xtp4ba7o8CS3R%2FduPuJLFY6fUexkHpvKj1Nn%2B31oQSjRywNhDdNvlczG4Z2LI73TdsZuCKnSPHNF7DNtOxmeGKZl9z9utufWZIb1FetBPy97bOOVKx69nZYTjmfv7hzBuEd5SweBD9QA2WspaycH9H01R4IXXcnrWKHkkaaVS3jDR%2F%2Bll4S0yGKlVT8EiRqLcZVX6mP2C7tmpbTE1tE%2F5ydEXkHMQ4Q75MDhO6F24ahX2rF%2FyfzuAMnR784wtXAM2E3hvVbCzu1rS9Xy1O7uSL%2Fzw1PxRlBZ%2FTwP00bUw22fQfnye%2Fb5s1NmvpWcrSX6tUNlK%2BrCHlfKSxWVhMWiZOqjMq9chUja87UzhcVXYBWZqhfuGsbRIoDQ40P6k7LDTuuzR7UuMU0nPFvGXsfwyu4UQzQppBmjwdQQlpo9GK2XAR7M2Wj5XNB5yZ3n8uMfW%2BktjiC0yW9bo0BVtvvmEOayXYwXyndHauAcJ0HpHnRLtnzNKnTKI3IY%2Fl4kYFS%2BiYUk6n0nd2eVKroYdrMjKZehZmpwmXfU3%2FWpwmt6HK%2FWKAWZzjlEUaN5zDbG%2BtGNxrjYaVvJuDn2uVtmozVU8dbCdz82O6sukqV5QZ86FFImnlZPOKcSHIFq%2F%2B1AdBG%2FUEKZ28aaadpm11H4ovyjAawjFwoWhtDsJB%2F1YbGDIqlKJ40ZOav8gu1Q%2Bv9UtpaQsDfm84FjlzlmwRQn2LF%2FBZLNmAjc8uug0sItSc2bX9d7gR9EWc3KML3PiBecc%2B6LfUkd5WyqHKPP%2FHDETbor16YGv%2Bt3d6KNtQgY3p%2B2Y8kVRCqtngKNzuid%2FXOmNTpwgKgj69id3uo8asDGcs%2B%2FVu5WjbkDNF%2FJlg2TWyTzwpr53wOKmm6tsWwf2FYScCHzXvfWjxHIR9qyGtIOembCqhaK%2Bv7NYDhaI8dAOtvz2su0yzecbzGa65MlwPIyRmv458OLvCMd1BLubANPxC3YfpMHm7x0JllAwNm4K%2BfM73Qkk6jsLwAr28YC1rvMCRONv4Q0sqEpuXfGbS212hv2LeVMq9wrORW353yq2MeRDxFnc2v0oTtVL9D7nlAlBXotJu4rT%2FzhFkH%2Be%2Fbmcbe1sgbaR4BIqrp65Nwq7RjjbB8FX8fi3xA%2BVE68b9DwmAMsub7oVbmI%2B09Wf85hjYjV5fS1xHdKqT6GRTqF9HhkiRxSIDKXzMM7pBXvzwuG%2BOWTVEBOgctSA2alhhyKvUBizsrW6TO%2FSPoX8n%2Fg3qUfufYGrb05PuoeDayC9iZEzmYc%3D"
+        in captured.out
+    )
 
 
-def test_fullrun_PBKDF1_MS_customkeys_onlyhashkeyfound(monkeypatch, capsys, mocker):
+def test_fullrun_PBKDF1_MS_customkeys_onlyhashkeyfound(monkeypatch, capsys, mocker, bh_mock):
     mocker.patch.object(
         Telerik_EncryptionKey,
         "prepare_keylist",
@@ -1092,49 +1147,55 @@ def test_fullrun_PBKDF1_MS_customkeys_onlyhashkeyfound(monkeypatch, capsys, mock
         return_value=iter(["Not_The_Real_HaSh_Key", "Y3t_anoth3r_f@k3_key"]),
     )
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF1_MS_version_probe_matcher_incorrect(request):
-                return httpx.Response(
-                    200,
-                    text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF1_MS_encryption_probe_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:Index was outside the bounds of the array.</div>")
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(200, text="Error Message:Length cannot be less than zero")
-            if PBKDF1_MS_found_key_matcher_negative(request):
-                return httpx.Response(200, text="<div>Error Message:The hash is not valid!</div>")
-            if PBKDF1_MS_found_key_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:The input data is not a complete block.</div>")
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF1_MS_version_probe_matcher_incorrect(request):
+            return MockResponse(
+                status_code=200,
+                text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF1_MS_encryption_probe_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Index was outside the bounds of the array.</div>"
+            )
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(status_code=200, text="Error Message:Length cannot be less than zero")
+        if PBKDF1_MS_found_key_matcher_negative(request):
+            return MockResponse(status_code=200, text="<div>Error Message:The hash is not valid!</div>")
+        if PBKDF1_MS_found_key_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:The input data is not a complete block.</div>"
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
-                "--debug",
-                "--custom-keys",
-                "NOPENOPENOPENOPE,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
-            ],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a valid DialogHandler endpoint. Brute forcing Telerik Hash Key" in captured.out
-        assert "Found matching hashkey: [YOUR_ENCRYPTION_KEY_TO_GO_HERE]" in captured.out
-        assert "FAILED: Could not identify encryption key." in captured.out
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+            "--debug",
+            "--custom-keys",
+            "NOPENOPENOPENOPE,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
+        ],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a valid DialogHandler endpoint. Brute forcing Telerik Hash Key" in captured.out
+    assert "Found matching hashkey: [YOUR_ENCRYPTION_KEY_TO_GO_HERE]" in captured.out
+    assert "FAILED: Could not identify encryption key." in captured.out
 
 
-def test_fullrun_PBKDF2_version_customkeys_nogoodversion(monkeypatch, capsys, mocker):
+def test_fullrun_PBKDF2_version_customkeys_nogoodversion(monkeypatch, capsys, mocker, bh_mock):
     def generate_keylist_enc(include_machinekeys):
         return iter(["Not_The_Real_Encryption_Key", "another_fake_encryption_key"])
 
@@ -1144,54 +1205,56 @@ def test_fullrun_PBKDF2_version_customkeys_nogoodversion(monkeypatch, capsys, mo
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF2_version_probe_matcher_incorrect(request):
-                return httpx.Response(
-                    200,
-                    text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
-                )
-            if PBKDF2_version_probe_matcher(request):
-                return httpx.Response(200, text="DoesntMatter")
-            if PBKDF2_found_key_matcher_negative(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
-                )
-            if PBKDF2_found_key_matcher(request):
-                return httpx.Response(
-                    200,
-                    text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF2_version_probe_matcher_incorrect(request):
+            return MockResponse(
+                status_code=200,
+                text="<title>telerik</title>Could not load file or assembly 'Telerik.Web.UI, Version=1984.5.622, Culture=neutral, PublicKeyToken=121fae78165ba3d4' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)",
+            )
+        if PBKDF2_version_probe_matcher(request):
+            return MockResponse(status_code=200, text="DoesntMatter")
+        if PBKDF2_found_key_matcher_negative(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
+            )
+        if PBKDF2_found_key_matcher(request):
+            return MockResponse(
+                status_code=200,
+                text="Please refresh the editor page.</div><div>Error Message:Index was outside the bounds of the array",
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
-                "--version",
-                "1944.6.6",
-                "--custom-keys",
-                "d2a312d9-7af4-43de-be5a-ae717b46cea6,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
-            ],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Target is a newer version of Telerik UI" in captured.out
-        assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert "SUCCESS! Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
-        assert "FAILED: Could not find a working version despite having valid keys." in captured.out
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+            "--version",
+            "1944.6.6",
+            "--custom-keys",
+            "d2a312d9-7af4-43de-be5a-ae717b46cea6,YOUR_ENCRYPTION_KEY_TO_GO_HERE",
+        ],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Target is a newer version of Telerik UI" in captured.out
+    assert "Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert "SUCCESS! Found encryption key: [d2a312d9-7af4-43de-be5a-ae717b46cea6]" in captured.out
+    assert "FAILED: Could not find a working version despite having valid keys." in captured.out
 
 
-def test_asyncupload_failure_no_keys_found(monkeypatch, capsys, mocker):
+def test_asyncupload_failure_no_keys_found(monkeypatch, capsys, mocker, bh_mock):
     """Test AsyncUpload case where no keys are found and failure message is printed"""
 
     def generate_keylist_enc(include_machinekeys):
@@ -1203,29 +1266,33 @@ def test_asyncupload_failure_no_keys_found(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
 
-        # All POST requests return failure
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=500, text="Some error"
-        )
+    # All POST requests return failure
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="POST",
+        status_code=500,
+        text="Some error",
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "Key(s) not found :(" in captured.out
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd", "--force"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "Key(s) not found :(" in captured.out
 
 
-def test_asyncupload_success_with_hashkey(monkeypatch, capsys, mocker):
+def test_asyncupload_success_with_hashkey(monkeypatch, capsys, mocker, bh_mock):
     """Test AsyncUpload success case where hashkey is included in vulnerability result output"""
 
     def generate_keylist_enc(include_machinekeys):
@@ -1237,39 +1304,42 @@ def test_asyncupload_success_with_hashkey(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="GET",
+        status_code=200,
+        text='{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }',
+    )
 
-        # Success response that includes fileInfo
-        respx.post("http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd").respond(
-            status_code=200,
-            text='{"fileInfo":{"FileName":"test","ContentType":"text/html","ContentLength":8,"DateJson":"2020-01-02T08:02:01.067Z","Index":0}}',
-        )
+    # Success response that includes fileInfo
+    bh_mock.add_response(
+        url="http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd?type=RAU",
+        method="POST",
+        status_code=200,
+        text='{"fileInfo":{"FileName":"test","ContentType":"text/html","ContentLength":8,"DateJson":"2020-01-02T08:02:01.067Z","Index":0}}',
+    )
 
-        monkeypatch.setattr(
-            "sys.argv",
-            [
-                "python",
-                "--url",
-                "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd",
-                "--force",
-                "--version",
-                "2018.1.117",
-            ],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        # Should include hash key in the output since it's not "dummyvalue"
-        assert "Hash Key: [test_hash_key]" in captured.out
-        assert "TARGET VULNERABLE!" in captured.out
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "python",
+            "--url",
+            "http://asyncupload.telerik.com/Telerik.Web.UI.WebResource.axd",
+            "--force",
+            "--version",
+            "2018.1.117",
+        ],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    # Should include hash key in the output since it's not "dummyvalue"
+    assert "Hash Key: [test_hash_key]" in captured.out
+    assert "TARGET VULNERABLE!" in captured.out
 
 
-def test_dialoghandler_probe_version_with_title(monkeypatch, capsys, mocker):
+def test_dialoghandler_probe_version_with_title(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler probe_version method with HTML title extraction from server response"""
 
     # Create a DialogHandler instance directly to test the probe_version method
@@ -1289,110 +1359,117 @@ def test_dialoghandler_probe_version_with_title(monkeypatch, capsys, mocker):
     dh.telerik_hashkey = mocker.Mock()
     dh.telerik_hashkey.sign_enc_dialog_params.return_value = "signed_params"
 
-    with respx.mock:
-        # Mock a response with title that has different size than baseline
-        def response_with_title(request):
-            return httpx.Response(
-                200,
-                text="<html><head><title>Test Telerik Page</title></head><body>Test response with different size</body></html>",
-            )
+    # Mock a response with title that has different size than baseline
+    def response_with_title(request):
+        return MockResponse(
+            status_code=200,
+            text="<html><head><title>Test Telerik Page</title></head><body>Test response with different size</body></html>",
+        )
 
-        respx.post("http://test.com").mock(side_effect=response_with_title)
+    bh_mock.add_callback(response_with_title, url="http://test.com")
 
-        # Call probe_version directly with a test version
-        dh.probe_version("2018.1.117", baseline_size=100)
-        captured = capsys.readouterr()
-        print(captured.out)
+    # Call probe_version directly with a test version
+    dh.probe_version("2018.1.117", baseline_size=100)
+    captured = capsys.readouterr()
+    print(captured.out)
 
-        # Should show title extraction in debug output
-        assert "Test Telerik Page" in captured.out
+    # Should show title extraction in debug output
+    assert "Test Telerik Page" in captured.out
 
 
-def test_dialoghandler_detect_derive_function_responses(monkeypatch, capsys, mocker):
+def test_dialoghandler_detect_derive_function_responses(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler detect_derive_function with different server error response messages"""
 
     # Test case 1: Exception response leading to PBKDF2 detection
-    with respx.mock:
-        respx.get("http://test.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    bh_mock.add_response(
+        url="http://test.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown</div>"
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown</div>"
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://test.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://test.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
-        )
+    bh_mock.add_callback(_post_dispatcher, url="http://test.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://test.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
+    )
 
-        # Mock solve_key to prevent full execution
-        mocker.patch.object(telerik_knownkey.DialogHandler, "solve_key", return_value=False)
+    # Mock solve_key to prevent full execution
+    mocker.patch.object(telerik_knownkey.DialogHandler, "solve_key", return_value=False)
 
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert (
-            "Target is a newer version of Telerik UI without verbose error messages. Hash key and Encryption key will have to BOTH match. PBKDF2 key derivation is used."
-            in captured.out
-        )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert (
+        "Target is a newer version of Telerik UI without verbose error messages. Hash key and Encryption key will have to BOTH match. PBKDF2 key derivation is used."
+        in captured.out
+    )
 
     # Test case 2: Length cannot be less than zero response leading to PBKDF1_MS detection
-    with respx.mock:
-        respx.get("http://test2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    bh_mock.add_response(
+        url="http://test2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(200, text="Error Message:Length cannot be less than zero")
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(status_code=200, text="Error Message:Length cannot be less than zero")
+        return MockResponse(status_code=200)
 
-        respx.post("http://test2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://test2.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
-        )
+    bh_mock.add_callback(_post_dispatcher, url="http://test2.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://test2.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
+    )
 
-        # Mock solve_key to prevent full execution
-        mocker.patch.object(telerik_knownkey.DialogHandler, "solve_key", return_value=False)
+    # Mock solve_key to prevent full execution
+    mocker.patch.object(telerik_knownkey.DialogHandler, "solve_key", return_value=False)
 
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert (
-            "Target is post-CVE-2017-9248 patched but old enough to use older PBKDF1_MS key dervivation. Hash key can be solved independently."
-            in captured.out
-        )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert (
+        "Target is post-CVE-2017-9248 patched but old enough to use older PBKDF1_MS key dervivation. Hash key can be solved independently."
+        in captured.out
+    )
 
     # Test case 3: Invalid Base-64 response causing early return
-    with respx.mock:
-        respx.get("http://test3.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    bh_mock.add_response(
+        url="http://test3.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        def _post_dispatcher(request):
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(200, text="Error Message:Invalid length for a Base-64 char array or string")
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(
+                status_code=200, text="Error Message:Invalid length for a Base-64 char array or string"
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://test3.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://test3.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
-        )
+    bh_mock.add_callback(_post_dispatcher, url="http://test3.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://test3.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
+    )
 
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        # Should return early and not proceed to brute forcing
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    # Should return early and not proceed to brute forcing
 
 
-def test_dialoghandler_pbkdf1_ms_failed_encryption_key(monkeypatch, capsys, mocker):
+def test_dialoghandler_pbkdf1_ms_failed_encryption_key(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler solve_key PBKDF1_MS scenario where hash key is found but encryption key fails"""
 
     mocker.patch.object(
@@ -1406,41 +1483,45 @@ def test_dialoghandler_pbkdf1_ms_failed_encryption_key(monkeypatch, capsys, mock
         return_value=iter(["YOUR_ENCRYPTION_KEY_TO_GO_HERE"]),
     )
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        # Successful hash key discovery + All encryption key attempts fail
-        def encryption_failure_matcher(request):
-            return "CaCbLSlA" in _body(request)
+    # Successful hash key discovery + All encryption key attempts fail
+    def encryption_failure_matcher(request):
+        return "CaCbLSlA" in _body(request)
 
-        def _post_dispatcher(request):
-            if encryption_failure_matcher(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Some other error that doesn't indicate success</div>"
-                )
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(200, text="Error Message:Length cannot be less than zero")
-            if PBKDF1_MS_found_key_matcher_negative(request):
-                return httpx.Response(200, text="<div>Error Message:The hash is not valid!</div>")
-            if PBKDF1_MS_found_key_matcher(request):
-                return httpx.Response(200, text="<div>Error Message:The input data is not a complete block.</div>")
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if encryption_failure_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Some other error that doesn't indicate success</div>"
+            )
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(status_code=200, text="Error Message:Length cannot be less than zero")
+        if PBKDF1_MS_found_key_matcher_negative(request):
+            return MockResponse(status_code=200, text="<div>Error Message:The hash is not valid!</div>")
+        if PBKDF1_MS_found_key_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:The input data is not a complete block.</div>"
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        assert "FAILED: Could not identify encryption key." in captured.out
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://PBKDF1_MS.telerik.com/Telerik.Web.UI.DialogHandler.aspx"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert "FAILED: Could not identify encryption key." in captured.out
 
 
-def test_dialoghandler_pbkdf2_mode_execution(monkeypatch, capsys, mocker):
+def test_dialoghandler_pbkdf2_mode_execution(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler solve_key PBKDF2 mode execution and encryption key brute force loop"""
 
     def generate_keylist_enc(include_machinekeys):
@@ -1452,39 +1533,41 @@ def test_dialoghandler_pbkdf2_mode_execution(monkeypatch, capsys, mocker):
     mocker.patch.object(Telerik_EncryptionKey, "prepare_keylist", side_effect=generate_keylist_enc)
     mocker.patch.object(Telerik_HashKey, "prepare_keylist", side_effect=generate_keylist_hash)
 
-    with respx.mock:
-        # Basic Probe Detects Telerik
-        respx.get("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").respond(
-            status_code=200, text=partial_dialog_page
-        )
+    # Basic Probe Detects Telerik
+    bh_mock.add_response(
+        url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx",
+        method="GET",
+        status_code=200,
+        text=partial_dialog_page,
+    )
 
-        # Detect PBKDF2 mode + All key combination attempts fail - no match found
-        def pbkdf2_failure_matcher(request):
-            return _body(request) != "dialogParametersHolder=AAAA"
+    # Detect PBKDF2 mode + All key combination attempts fail - no match found
+    def pbkdf2_failure_matcher(request):
+        return _body(request) != "dialogParametersHolder=AAAA"
 
-        def _post_dispatcher(request):
-            if pbkdf2_failure_matcher(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
-                )
-            if PBKDF1_MS_probe_matcher(request):
-                return httpx.Response(
-                    200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
-                )
-            return httpx.Response(200)
+    def _post_dispatcher(request):
+        if pbkdf2_failure_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
+            )
+        if PBKDF1_MS_probe_matcher(request):
+            return MockResponse(
+                status_code=200, text="<div>Error Message:Exception of type 'System.Exception' was thrown.</div>"
+            )
+        return MockResponse(status_code=200)
 
-        respx.post("http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx").mock(side_effect=_post_dispatcher)
-        monkeypatch.setattr(
-            "sys.argv",
-            ["python", "--url", "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
-        )
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        print(captured.out)
-        # Should enter PBKDF2 mode and try key combinations
-        assert "Target is a newer version of Telerik UI" in captured.out
-        assert "Brute forcing hash key and encryption key combinations..." in captured.out
-        assert "FAILED: Did not find hashkey / encryption key. Exiting." in captured.out
+    bh_mock.add_callback(_post_dispatcher, url="http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["python", "--url", "http://PBKDF2.telerik.com/Telerik.Web.UI.DialogHandler.aspx", "--debug"],
+    )
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    print(captured.out)
+    # Should enter PBKDF2 mode and try key combinations
+    assert "Target is a newer version of Telerik UI" in captured.out
+    assert "Brute forcing hash key and encryption key combinations..." in captured.out
+    assert "FAILED: Did not find hashkey / encryption key. Exiting." in captured.out
 
 
 def test_dialoghandler_solve_key_failure_and_version_solve(monkeypatch, capsys, mocker):
@@ -1519,7 +1602,7 @@ def test_dialoghandler_solve_key_failure_and_version_solve(monkeypatch, capsys, 
     assert "Keys found! Now attempting to find the exact Telerik UI version..." in captured.out
 
 
-def test_argument_parsing_machine_keys_and_force(monkeypatch, capsys, mocker):
+def test_argument_parsing_machine_keys_and_force(monkeypatch, capsys, mocker, bh_mock):
     """Test argument parser handling for machine-keys and force command line flags"""
 
     # Test machine-keys flag
@@ -1529,15 +1612,16 @@ def test_argument_parsing_machine_keys_and_force(monkeypatch, capsys, mocker):
     )
 
     # Mock HTTP calls to prevent actual network calls
-    with respx.mock:
-        respx.get("http://test.com").respond(status_code=200, text="Loading the dialog...")
-        respx.post("http://test.com").respond(status_code=200, text="Error Message:Length cannot be less than zero")
-        # Mock solve_key to prevent full execution
-        mocker.patch("badsecrets.examples.telerik_knownkey.DialogHandler.solve_key", return_value=False)
+    bh_mock.add_response(url="http://test.com", method="GET", status_code=200, text="Loading the dialog...")
+    bh_mock.add_response(
+        url="http://test.com", method="POST", status_code=200, text="Error Message:Length cannot be less than zero"
+    )
+    # Mock solve_key to prevent full execution
+    mocker.patch("badsecrets.examples.telerik_knownkey.DialogHandler.solve_key", return_value=False)
 
-        telerik_knownkey.main()
-        captured = capsys.readouterr()
-        assert "MachineKeys inclusion enabled. Bruteforcing will take SIGNIFICANTLY longer" in captured.out
+    telerik_knownkey.main()
+    captured = capsys.readouterr()
+    assert "MachineKeys inclusion enabled. Bruteforcing will take SIGNIFICANTLY longer" in captured.out
 
 
 def test_asyncupload_no_keys_found_message(monkeypatch, capsys, mocker):
@@ -1562,7 +1646,7 @@ def test_asyncupload_no_keys_found_message(monkeypatch, capsys, mocker):
     assert "Key(s) not found :(" in captured.out
 
 
-def test_asyncupload_network_connection_error(monkeypatch, capsys, mocker):
+def test_asyncupload_network_connection_error(monkeypatch, capsys, mocker, bh_mock):
     """Test AsyncUpload handles network connection errors during key solving"""
 
     from badsecrets.examples.telerik_knownkey import AsyncUpload
@@ -1583,25 +1667,24 @@ def test_asyncupload_network_connection_error(monkeypatch, capsys, mocker):
     # Mock version_probe to skip version checking
     mocker.patch.object(au, "version_probe")
 
-    with respx.mock:
-        # Network error on POST request - this will trigger the exception handling
-        respx.post("http://test.com").mock(side_effect=httpx.ConnectError("Connection failed"))
+    # Network error on POST request - this will trigger the exception handling
+    def _err(req):
+        raise RuntimeError("Connection failed")
 
-        with patch("sys.exit") as exit_mock:
-            try:
-                au.solve_key()
-            except UnboundLocalError:
-                # Expected - happens after sys.exit(1) due to bug in original code
-                pass
-            captured = capsys.readouterr()
-            assert (
-                "Network error connecting to URL: [http://test.com]. Exiting due to connection failure."
-                in captured.out
-            )
-            assert exit_mock.called
+    bh_mock.add_callback(_err, url="http://test.com")
+
+    with patch("sys.exit") as exit_mock:
+        try:
+            au.solve_key()
+        except UnboundLocalError:
+            # Expected - happens after sys.exit(1) due to bug in original code
+            pass
+        captured = capsys.readouterr()
+        assert "Network error connecting to URL: [http://test.com]. Exiting due to connection failure." in captured.out
+        assert exit_mock.called
 
 
-def test_dialoghandler_probe_version_baseline_network_error(monkeypatch, capsys, mocker):
+def test_dialoghandler_probe_version_baseline_network_error(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler probe_version_baseline handles network errors"""
 
     from badsecrets.examples.telerik_knownkey import DialogHandler
@@ -1620,20 +1703,24 @@ def test_dialoghandler_probe_version_baseline_network_error(monkeypatch, capsys,
     dh.telerik_hashkey = mocker.Mock()
     dh.telerik_hashkey.sign_enc_dialog_params.return_value = "signed_params"
 
-    # Mock httpx.post to raise a connection error
-    with patch("httpx.post", side_effect=httpx.ConnectError("Connection failed")):
-        with patch("sys.exit") as exit_mock:
-            try:
-                dh.probe_version_baseline()
-            except UnboundLocalError:
-                # Expected - happens after sys.exit(1) due to bug in original code
-                pass
-            captured = capsys.readouterr()
-            assert "[DEBUG] Network error probing version, exiting" in captured.out
-            assert exit_mock.called
+    # Network error on POST request
+    def _err(req):
+        raise RuntimeError("Connection failed")
+
+    bh_mock.add_callback(_err, url="http://test.com")
+
+    with patch("sys.exit") as exit_mock:
+        try:
+            dh.probe_version_baseline()
+        except UnboundLocalError:
+            # Expected - happens after sys.exit(1) due to bug in original code
+            pass
+        captured = capsys.readouterr()
+        assert "[DEBUG] Network error probing version, exiting" in captured.out
+        assert exit_mock.called
 
 
-def test_dialoghandler_probe_version_network_error(monkeypatch, capsys, mocker):
+def test_dialoghandler_probe_version_network_error(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler probe_version handles network errors"""
 
     from badsecrets.examples.telerik_knownkey import DialogHandler
@@ -1652,20 +1739,23 @@ def test_dialoghandler_probe_version_network_error(monkeypatch, capsys, mocker):
     dh.telerik_hashkey = mocker.Mock()
     dh.telerik_hashkey.sign_enc_dialog_params.return_value = "signed_params"
 
-    # Mock httpx.post to raise a connection error
-    with patch("httpx.post", side_effect=httpx.ConnectTimeout("Connection timeout")):
-        with patch("sys.exit") as exit_mock:
-            try:
-                dh.probe_version("2018.1.117", baseline_size=100)
-            except UnboundLocalError:
-                # Expected - happens after sys.exit(1) due to bug in original code
-                pass
-            captured = capsys.readouterr()
-            assert "[DEBUG] Network error probing version, exiting" in captured.out
-            assert exit_mock.called
+    def _err(req):
+        raise RuntimeError("Connection timeout")
+
+    bh_mock.add_callback(_err, url="http://test.com")
+
+    with patch("sys.exit") as exit_mock:
+        try:
+            dh.probe_version("2018.1.117", baseline_size=100)
+        except UnboundLocalError:
+            # Expected - happens after sys.exit(1) due to bug in original code
+            pass
+        captured = capsys.readouterr()
+        assert "[DEBUG] Network error probing version, exiting" in captured.out
+        assert exit_mock.called
 
 
-def test_dialoghandler_detect_derive_function_network_error(monkeypatch, capsys, mocker):
+def test_dialoghandler_detect_derive_function_network_error(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler detect_derive_function handles network errors"""
 
     from badsecrets.examples.telerik_knownkey import DialogHandler
@@ -1673,23 +1763,26 @@ def test_dialoghandler_detect_derive_function_network_error(monkeypatch, capsys,
     dh = DialogHandler("http://test.com")
     dh.debug = True
 
-    # Mock httpx.post to raise a TooManyRedirects error
-    with patch("httpx.post", side_effect=httpx.TooManyRedirects("Too many redirects")):
-        with patch("sys.exit") as exit_mock:
-            try:
-                dh.detect_derive_function()
-            except UnboundLocalError:
-                # Expected - happens after sys.exit(1) due to bug in original code
-                pass
-            captured = capsys.readouterr()
-            assert (
-                "Network error connecting to URL: [http://test.com]. Cannot determine key derivation function."
-                in captured.out
-            )
-            assert exit_mock.called
+    def _err(req):
+        raise RuntimeError("Too many redirects")
+
+    bh_mock.add_callback(_err, url="http://test.com")
+
+    with patch("sys.exit") as exit_mock:
+        try:
+            dh.detect_derive_function()
+        except UnboundLocalError:
+            # Expected - happens after sys.exit(1) due to bug in original code
+            pass
+        captured = capsys.readouterr()
+        assert (
+            "Network error connecting to URL: [http://test.com]. Cannot determine key derivation function."
+            in captured.out
+        )
+        assert exit_mock.called
 
 
-def test_dialoghandler_solve_key_pbkdf1_ms_network_error(monkeypatch, capsys, mocker):
+def test_dialoghandler_solve_key_pbkdf1_ms_network_error(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler solve_key PBKDF1_MS handles network errors during hash key testing"""
 
     from badsecrets.examples.telerik_knownkey import DialogHandler
@@ -1706,23 +1799,23 @@ def test_dialoghandler_solve_key_pbkdf1_ms_network_error(monkeypatch, capsys, mo
     dh.telerik_hashkey = mocker.Mock()
     dh.telerik_hashkey.hashkey_probe_generator = mock_hashkey_probe_generator
 
-    # Mock httpx.post to raise a ConnectError (replaces MaxRetryError from urllib3)
-    with patch("httpx.post", side_effect=httpx.ConnectError("Max retries exceeded")):
-        with patch("sys.exit") as exit_mock:
-            try:
-                dh.solve_key()
-            except UnboundLocalError:
-                # Expected - happens after sys.exit(1) due to bug in original code
-                pass
-            captured = capsys.readouterr()
-            assert (
-                "Network error connecting to URL: [http://test.com]. Exiting due to connection failure."
-                in captured.out
-            )
-            assert exit_mock.called
+    def _err(req):
+        raise RuntimeError("Max retries exceeded")
+
+    bh_mock.add_callback(_err, url="http://test.com")
+
+    with patch("sys.exit") as exit_mock:
+        try:
+            dh.solve_key()
+        except UnboundLocalError:
+            # Expected - happens after sys.exit(1) due to bug in original code
+            pass
+        captured = capsys.readouterr()
+        assert "Network error connecting to URL: [http://test.com]. Exiting due to connection failure." in captured.out
+        assert exit_mock.called
 
 
-def test_dialoghandler_solve_key_pbkdf1_ms_encryption_network_error(monkeypatch, capsys, mocker):
+def test_dialoghandler_solve_key_pbkdf1_ms_encryption_network_error(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler solve_key PBKDF1_MS handles network errors during encryption key testing"""
 
     from badsecrets.examples.telerik_knownkey import DialogHandler
@@ -1740,23 +1833,23 @@ def test_dialoghandler_solve_key_pbkdf1_ms_encryption_network_error(monkeypatch,
     dh.telerik_encryptionkey = mocker.Mock()
     dh.telerik_encryptionkey.encryptionkey_probe_generator = mock_encryptionkey_probe_generator
 
-    # Mock httpx.post to raise a ConnectionError
-    with patch("httpx.post", side_effect=httpx.ConnectError("Connection failed")):
-        with patch("sys.exit") as exit_mock:
-            try:
-                dh.solve_key()
-            except UnboundLocalError:
-                # Expected - happens after sys.exit(1) due to bug in original code
-                pass
-            captured = capsys.readouterr()
-            assert (
-                "Network error connecting to URL: [http://test.com]. Exiting due to connection failure."
-                in captured.out
-            )
-            assert exit_mock.called
+    def _err(req):
+        raise RuntimeError("Connection failed")
+
+    bh_mock.add_callback(_err, url="http://test.com")
+
+    with patch("sys.exit") as exit_mock:
+        try:
+            dh.solve_key()
+        except UnboundLocalError:
+            # Expected - happens after sys.exit(1) due to bug in original code
+            pass
+        captured = capsys.readouterr()
+        assert "Network error connecting to URL: [http://test.com]. Exiting due to connection failure." in captured.out
+        assert exit_mock.called
 
 
-def test_dialoghandler_solve_key_pbkdf2_network_error(monkeypatch, capsys, mocker):
+def test_dialoghandler_solve_key_pbkdf2_network_error(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler solve_key PBKDF2 handles network errors during baseline establishment"""
 
     from badsecrets.examples.telerik_knownkey import DialogHandler
@@ -1774,23 +1867,26 @@ def test_dialoghandler_solve_key_pbkdf2_network_error(monkeypatch, capsys, mocke
     dh.telerik_hashkey = mocker.Mock()
     dh.telerik_hashkey.sign_enc_dialog_params.return_value = "signed_params"
 
-    # Mock httpx.post to raise a ConnectTimeout on baseline request
-    with patch("httpx.post", side_effect=httpx.ConnectTimeout("Connection timeout")):
-        with patch("sys.exit") as exit_mock:
-            try:
-                dh.solve_key()
-            except UnboundLocalError:
-                # Expected - happens after sys.exit(1) due to bug in original code
-                pass
-            captured = capsys.readouterr()
-            assert (
-                "Network error connecting to URL: [http://test.com]. Cannot establish baseline for testing."
-                in captured.out
-            )
-            assert exit_mock.called
+    def _err(req):
+        raise RuntimeError("Connection timeout")
+
+    bh_mock.add_callback(_err, url="http://test.com")
+
+    with patch("sys.exit") as exit_mock:
+        try:
+            dh.solve_key()
+        except UnboundLocalError:
+            # Expected - happens after sys.exit(1) due to bug in original code
+            pass
+        captured = capsys.readouterr()
+        assert (
+            "Network error connecting to URL: [http://test.com]. Cannot establish baseline for testing."
+            in captured.out
+        )
+        assert exit_mock.called
 
 
-def test_dialoghandler_solve_key_pbkdf2_key_testing_network_error(monkeypatch, capsys, mocker):
+def test_dialoghandler_solve_key_pbkdf2_key_testing_network_error(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler solve_key PBKDF2 handles network errors during key combination testing"""
 
     from badsecrets.examples.telerik_knownkey import DialogHandler
@@ -1821,35 +1917,30 @@ def test_dialoghandler_solve_key_pbkdf2_key_testing_network_error(monkeypatch, c
 
     call_count = 0
 
-    def mock_post(*args, **kwargs):
+    def _dispatcher(req):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             # First call is baseline - return success
-            response = mocker.Mock()
-            response.text = "baseline response"
-            response.status_code = 200
-            return response
+            return MockResponse(status_code=200, text="baseline response")
         else:
             # Second call for key testing - raise error
-            raise httpx.TooManyRedirects("Too many redirects")
+            raise RuntimeError("Too many redirects")
 
-    with patch("httpx.post", side_effect=mock_post):
-        with patch("sys.exit") as exit_mock:
-            try:
-                dh.solve_key()
-            except (UnboundLocalError, TypeError):
-                # Expected - happens after sys.exit(1) due to bug in original code
-                pass
-            captured = capsys.readouterr()
-            assert (
-                "Network error connecting to URL: [http://test.com]. Exiting due to connection failure."
-                in captured.out
-            )
-            assert exit_mock.called
+    bh_mock.add_callback(_dispatcher, url="http://test.com")
+
+    with patch("sys.exit") as exit_mock:
+        try:
+            dh.solve_key()
+        except (UnboundLocalError, TypeError):
+            # Expected - happens after sys.exit(1) due to bug in original code
+            pass
+        captured = capsys.readouterr()
+        assert "Network error connecting to URL: [http://test.com]. Exiting due to connection failure." in captured.out
+        assert exit_mock.called
 
 
-def test_dialoghandler_pbkdf1_ms_encryption_key_final_network_error(monkeypatch, capsys, mocker):
+def test_dialoghandler_pbkdf1_ms_encryption_key_final_network_error(monkeypatch, capsys, mocker, bh_mock):
     """Test DialogHandler solve_key PBKDF1_MS encryption key testing network exception handling to achieve 100% coverage"""
 
     from badsecrets.examples.telerik_knownkey import DialogHandler
@@ -1873,43 +1964,22 @@ def test_dialoghandler_pbkdf1_ms_encryption_key_final_network_error(monkeypatch,
 
     dh.telerik_encryptionkey.encryptionkey_probe_generator = mock_encryptionkey_probe_generator
 
-    # Mock the initial hash key request to succeed
-    def mock_post_hash_key_success(*args, **kwargs):
-        response = mocker.Mock()
-        response.text = "The input data is not a complete block"  # Hash key success
-        response.status_code = 200
-        return response
-
-    # Mock the encryption key request to raise network exception
-    def mock_post_encryption_key_network_error(*args, **kwargs):
-        # Check if this is the encryption key testing request
-        if "dialogParametersHolder" in kwargs.get("data", {}):
-            # Raise network exception for encryption key testing
-            raise httpx.ConnectError("Network error during encryption key testing")
-        else:
-            # For other calls, return success
-            response = mocker.Mock()
-            response.text = "The input data is not a complete block"
-            response.status_code = 200
-            return response
-
     # Set up the sequence: hash key success, then encryption key network error
     call_count = [0]
 
-    def mock_post_sequence(*args, **kwargs):
+    def _dispatcher(req):
         call_count[0] += 1
         if call_count[0] == 1:
             # First call (hash key) succeeds
-            return mock_post_hash_key_success(*args, **kwargs)
+            return MockResponse(status_code=200, text="The input data is not a complete block")
         else:
             # Second call (encryption key) raises network error
-            return mock_post_encryption_key_network_error(*args, **kwargs)
+            raise RuntimeError("Network error during encryption key testing")
+
+    bh_mock.add_callback(_dispatcher, url="http://test.com")
 
     # Mock sys.exit to prevent actual exit
     mocker.patch("sys.exit")
-
-    # Apply the mock
-    mocker.patch("httpx.post", side_effect=mock_post_sequence)
 
     # Call solve_key - this should trigger the network exception in encryption key testing
     dh.solve_key()

--- a/tests/globalprotect_test.py
+++ b/tests/globalprotect_test.py
@@ -1,9 +1,18 @@
 import asyncio
 import unittest.mock as mock
-import httpx
-import respx
+from blasthttp.mock import BlasthttpMock, MockResponse
 from badsecrets.base import yara_prefilter_scan, probe_all_modules
 from badsecrets.modules.active.globalprotect import GlobalProtect_DefaultMasterKey
+
+
+class FakeResponse:
+    """Duck-typed HTTP response for probe_all_modules tests."""
+
+    def __init__(self, text="", headers=None, cookies=None, url=""):
+        self.text = text
+        self.headers = headers if headers is not None else {}
+        self.cookies = cookies if cookies is not None else {}
+        self.url = url
 
 
 # Sample HTML that looks like a GlobalProtect portal
@@ -66,14 +75,17 @@ def test_crypto_build_cookie():
     assert cookie.startswith("AQ==")
 
 
-@respx.mock
+def _mock_static(url, text, status=200, method="POST"):
+    bh = BlasthttpMock()
+    bh.add_response(url=url, method=method, text=text, status_code=status)
+    return bh
+
+
 def test_probe_default_key_found():
     """Mock /sslmgr returning 'Unable to find the configuration' -> SecretFound."""
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
-    )
+    bh = _mock_static("https://vpn.example.com/sslmgr", "Unable to find the configuration")
 
-    gp = GlobalProtect_DefaultMasterKey()
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     results = asyncio.run(gp.probe("https://vpn.example.com/global-protect/login.esp"))
     assert len(results) == 1
     assert results[0]["type"] == "SecretFound"
@@ -82,14 +94,11 @@ def test_probe_default_key_found():
     assert "p1a2l3o4a5l6t7o8" in results[0]["secret"]
 
 
-@respx.mock
 def test_probe_scep_enabled():
     """Mock returning 'Unable to generate client certificate' -> SecretFound with CVE."""
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to generate client certificate")
-    )
+    bh = _mock_static("https://vpn.example.com/sslmgr", "Unable to generate client certificate")
 
-    gp = GlobalProtect_DefaultMasterKey()
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     results = asyncio.run(gp.probe("https://vpn.example.com"))
     assert len(results) == 1
     assert results[0]["type"] == "SecretFound"
@@ -97,42 +106,39 @@ def test_probe_scep_enabled():
     assert results[0]["details"]["cve"] == "CVE-2021-3060"
 
 
-@respx.mock
 def test_probe_key_rejected():
     """Mock returning 'Invalid Cookie' -> no result."""
-    respx.post("https://vpn.example.com/sslmgr").mock(return_value=httpx.Response(200, text="Invalid Cookie"))
+    bh = _mock_static("https://vpn.example.com/sslmgr", "Invalid Cookie")
 
-    gp = GlobalProtect_DefaultMasterKey()
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     results = asyncio.run(gp.probe("https://vpn.example.com"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_connection_error():
     """Mock raising exception -> no crash, no result."""
-    respx.post("https://vpn.example.com/sslmgr").mock(side_effect=httpx.ConnectError("Connection refused"))
 
-    gp = GlobalProtect_DefaultMasterKey()
+    def _err(req):
+        raise RuntimeError("Connection refused")
+
+    bh = BlasthttpMock()
+    bh.add_callback(_err, url="https://vpn.example.com/sslmgr")
+
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     results = asyncio.run(gp.probe("https://vpn.example.com"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_custom_key():
-    """Custom key finds a non-default key."""
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
-    )
+    """Custom key alongside default — default matches first."""
+    bh = _mock_static("https://vpn.example.com/sslmgr", "Unable to find the configuration")
 
-    gp = GlobalProtect_DefaultMasterKey()
-    # The default key will also match, so we test that custom keys are tried
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     results = asyncio.run(gp.probe("https://vpn.example.com", custom_keys=["mycustomkey123"]))
-    # Default key matches first
     assert len(results) >= 1
     assert results[0]["details"]["is_default_key"] is True
 
 
-@respx.mock
 def test_probe_only_custom_key_matches():
     """Only custom key matches, default key is rejected."""
     call_count = 0
@@ -142,38 +148,31 @@ def test_probe_only_custom_key_matches():
         call_count += 1
         if call_count == 1:
             # First call (default key) -> rejected
-            return httpx.Response(200, text="Invalid Cookie")
-        else:
-            # Second call (custom key) -> found
-            return httpx.Response(200, text="Unable to find the configuration")
+            return MockResponse(text="Invalid Cookie", status_code=200)
+        # Second call (custom key) -> found
+        return MockResponse(text="Unable to find the configuration", status_code=200)
 
-    respx.post("https://vpn.example.com/sslmgr").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://vpn.example.com/sslmgr")
 
-    gp = GlobalProtect_DefaultMasterKey()
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     results = asyncio.run(gp.probe("https://vpn.example.com", custom_keys=["mycustomkey123"]))
     assert len(results) == 1
     assert results[0]["details"]["is_default_key"] is False
     assert results[0]["details"]["key"] == "mycustomkey123"
 
 
-@respx.mock
 def test_probe_all_modules_integration():
     """Full flow: response -> prefilter -> probe -> result."""
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
-    )
+    bh = _mock_static("https://vpn.example.com/sslmgr", "Unable to find the configuration")
 
-    # Create a mock httpx response for the initial page
-    mock_response = httpx.Response(
-        200,
-        text=GLOBALPROTECT_PORTAL_HTML,
-        request=httpx.Request("GET", "https://vpn.example.com"),
-    )
+    mock_response = FakeResponse(text=GLOBALPROTECT_PORTAL_HTML, url="https://vpn.example.com")
 
     results = asyncio.run(
         probe_all_modules(
-            httpx_response=mock_response,
+            http_response=mock_response,
             url="https://vpn.example.com",
+            http_client=bh,
         )
     )
     assert len(results) >= 1
@@ -183,18 +182,13 @@ def test_probe_all_modules_integration():
     assert results[0]["description"]["severity"] == "CRITICAL"
 
 
-@respx.mock
 def test_probe_all_modules_no_prefilter_match():
     """Unrelated response -> no prefilter match -> no probes fired."""
-    mock_response = httpx.Response(
-        200,
-        text=UNRELATED_HTML,
-        request=httpx.Request("GET", "https://example.com"),
-    )
+    mock_response = FakeResponse(text=UNRELATED_HTML, url="https://example.com")
 
     results = asyncio.run(
         probe_all_modules(
-            httpx_response=mock_response,
+            http_response=mock_response,
             url="https://example.com",
         )
     )
@@ -208,35 +202,24 @@ def test_probe_invalid_url():
     assert results == []
 
 
-@respx.mock
 def test_probe_with_http_client():
     """Probe uses provided http_client instead of creating its own."""
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
-    )
+    bh = _mock_static("https://vpn.example.com/sslmgr", "Unable to find the configuration")
 
-    async def run():
-        async with httpx.AsyncClient() as client:
-            gp = GlobalProtect_DefaultMasterKey(http_client=client)
-            return await gp.probe("https://vpn.example.com")
-
-    results = asyncio.run(run())
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
+    results = asyncio.run(gp.probe("https://vpn.example.com"))
     assert len(results) == 1
 
 
-@respx.mock
 def test_probe_unexpected_response():
     """Response with unexpected text triggers debug log, no result."""
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Something completely different")
-    )
+    bh = _mock_static("https://vpn.example.com/sslmgr", "Something completely different")
 
-    gp = GlobalProtect_DefaultMasterKey()
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     results = asyncio.run(gp.probe("https://vpn.example.com"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_resource_file_extra_key():
     """Keys from resource file beyond the default key are tried."""
     call_count = 0
@@ -245,15 +228,13 @@ def test_probe_resource_file_extra_key():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            # Default key -> rejected
-            return httpx.Response(200, text="Invalid Cookie")
-        else:
-            # Extra resource key -> found
-            return httpx.Response(200, text="Unable to find the configuration")
+            return MockResponse(text="Invalid Cookie", status_code=200)
+        return MockResponse(text="Unable to find the configuration", status_code=200)
 
-    respx.post("https://vpn.example.com/sslmgr").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://vpn.example.com/sslmgr")
 
-    gp = GlobalProtect_DefaultMasterKey()
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     with mock.patch.object(gp, "load_resources", return_value=["p1a2l3o4a5l6t7o8\n", "extra_key_from_file\n"]):
         results = asyncio.run(gp.probe("https://vpn.example.com"))
     assert len(results) == 1
@@ -261,25 +242,26 @@ def test_probe_resource_file_extra_key():
     assert results[0]["details"]["is_default_key"] is False
 
 
-@respx.mock
 def test_probe_resource_file_missing():
     """Missing resource file doesn't crash — falls back to default key only."""
-    respx.post("https://vpn.example.com/sslmgr").mock(
-        return_value=httpx.Response(200, text="Unable to find the configuration")
-    )
+    bh = _mock_static("https://vpn.example.com/sslmgr", "Unable to find the configuration")
 
-    gp = GlobalProtect_DefaultMasterKey()
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     with mock.patch.object(gp, "load_resources", side_effect=FileNotFoundError):
         results = asyncio.run(gp.probe("https://vpn.example.com"))
     assert len(results) == 1
     assert results[0]["details"]["is_default_key"] is True
 
 
-@respx.mock
 def test_probe_exception_during_key_attempt():
     """Exception during key probe doesn't crash."""
-    respx.post("https://vpn.example.com/sslmgr").mock(side_effect=httpx.ReadTimeout("timeout"))
 
-    gp = GlobalProtect_DefaultMasterKey()
+    def _err(req):
+        raise RuntimeError("timeout")
+
+    bh = BlasthttpMock()
+    bh.add_callback(_err, url="https://vpn.example.com/sslmgr")
+
+    gp = GlobalProtect_DefaultMasterKey(http_client=bh)
     results = asyncio.run(gp.probe("https://vpn.example.com"))
     assert len(results) == 0

--- a/tests/ltpa_active_test.py
+++ b/tests/ltpa_active_test.py
@@ -1,8 +1,26 @@
 import asyncio
-import httpx
-import respx
+from blasthttp.mock import BlasthttpMock, MockResponse
 from badsecrets.base import yara_prefilter_scan, probe_all_modules
 from badsecrets.modules.active.ltpa_token import LTPA_Token_Key, forge_ltpa2_token
+
+
+class FakeResponse:
+    """Duck-typed HTTP response for probe_all_modules tests."""
+
+    def __init__(self, text="", headers=None, cookies=None, url=""):
+        self.text = text
+        self.headers = headers if headers is not None else {}
+        self.cookies = cookies if cookies is not None else {}
+        self.url = url
+
+
+def _cookie_value(req):
+    """Case-insensitive lookup of the Cookie header on a MockRequest."""
+    for k, v in req.headers.items():
+        if k.lower() == "cookie":
+            return v
+    return ""
+
 
 WEBSPHERE_LOGIN_HTML = """
 <html>
@@ -45,29 +63,19 @@ def test_prefilter_miss():
     assert "LTPA_Token_Key" not in result
 
 
-@respx.mock
 def test_probe_key_found():
     """Baseline 302, forged token 200 -> SecretFound."""
-    call_count = 0
 
     def side_effect(request):
-        nonlocal call_count
-        call_count += 1
-        cookie_header = request.headers.get("cookie", "")
+        cookie_header = _cookie_value(request)
         if "LtpaToken2=" in cookie_header:
-            # Forged token accepted
-            return httpx.Response(200, text="<html>Admin Console</html>")
-        else:
-            # No token / baseline -> redirect to login
-            return httpx.Response(
-                302,
-                text="",
-                headers={"Location": "/ibm/console/login"},
-            )
+            return MockResponse(text="<html>Admin Console</html>", status_code=200)
+        return MockResponse(text="", status_code=302, headers={"Location": "/ibm/console/login"})
 
-    respx.get("https://websphere.example.com/ibm/console").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://websphere.example.com/ibm/console")
 
-    gp = LTPA_Token_Key()
+    gp = LTPA_Token_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://websphere.example.com/ibm/console"))
     assert len(results) >= 1
     assert results[0]["type"] == "SecretFound"
@@ -75,40 +83,40 @@ def test_probe_key_found():
     assert "ltpa_active_keys.json" in results[0]["secret"]
 
 
-@respx.mock
 def test_probe_key_rejected():
     """All keys rejected (always 302) -> no results."""
 
     def always_redirect(request):
-        return httpx.Response(
-            302,
-            text="",
-            headers={"Location": "/ibm/console/login"},
-        )
+        return MockResponse(text="", status_code=302, headers={"Location": "/ibm/console/login"})
 
-    respx.get("https://websphere.example.com/ibm/console").mock(side_effect=always_redirect)
+    bh = BlasthttpMock()
+    bh.add_callback(always_redirect, url="https://websphere.example.com/ibm/console")
 
-    gp = LTPA_Token_Key()
+    gp = LTPA_Token_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://websphere.example.com/ibm/console"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_not_protected():
     """Baseline 200 (no auth required) -> no probes sent."""
-    respx.get("https://example.com/app").mock(return_value=httpx.Response(200, text="<html>Public page</html>"))
+    bh = BlasthttpMock()
+    bh.add_response(url="https://example.com/app", text="<html>Public page</html>", status_code=200)
 
-    gp = LTPA_Token_Key()
+    gp = LTPA_Token_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://example.com/app"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_connection_error():
     """Connection error -> no crash, no results."""
-    respx.get("https://websphere.example.com/ibm/console").mock(side_effect=httpx.ConnectError("Connection refused"))
 
-    gp = LTPA_Token_Key()
+    def _err(req):
+        raise RuntimeError("Connection refused")
+
+    bh = BlasthttpMock()
+    bh.add_callback(_err, url="https://websphere.example.com/ibm/console")
+
+    gp = LTPA_Token_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://websphere.example.com/ibm/console"))
     assert len(results) == 0
 
@@ -120,37 +128,29 @@ def test_probe_invalid_url():
     assert results == []
 
 
-@respx.mock
 def test_probe_all_modules_integration():
     """Full flow: response with WebSphere headers -> prefilter -> probe -> result."""
-    call_count = 0
 
     def side_effect(request):
-        nonlocal call_count
-        call_count += 1
-        cookie_header = request.headers.get("cookie", "")
+        cookie_header = _cookie_value(request)
         if "LtpaToken2=" in cookie_header:
-            return httpx.Response(200, text="<html>Admin Console</html>")
-        else:
-            return httpx.Response(
-                302,
-                text="",
-                headers={"Location": "/ibm/console/login"},
-            )
+            return MockResponse(text="<html>Admin Console</html>", status_code=200)
+        return MockResponse(text="", status_code=302, headers={"Location": "/ibm/console/login"})
 
-    respx.get("https://websphere.example.com/ibm/console").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://websphere.example.com/ibm/console")
 
-    mock_response = httpx.Response(
-        302,
+    mock_response = FakeResponse(
         text=WEBSPHERE_LOGIN_HTML,
         headers={"Set-Cookie": "LtpaToken2=expired; Path=/"},
-        request=httpx.Request("GET", "https://websphere.example.com/ibm/console"),
+        url="https://websphere.example.com/ibm/console",
     )
 
     results = asyncio.run(
         probe_all_modules(
-            httpx_response=mock_response,
+            http_response=mock_response,
             url="https://websphere.example.com/ibm/console",
+            http_client=bh,
         )
     )
     assert len(results) >= 1
@@ -160,18 +160,13 @@ def test_probe_all_modules_integration():
     assert results[0]["description"]["severity"] == "HIGH"
 
 
-@respx.mock
 def test_probe_all_modules_no_prefilter_match():
     """Unrelated response -> no prefilter match -> no probes fired."""
-    mock_response = httpx.Response(
-        200,
-        text=UNRELATED_HTML,
-        request=httpx.Request("GET", "https://example.com"),
-    )
+    mock_response = FakeResponse(text=UNRELATED_HTML, url="https://example.com")
 
     results = asyncio.run(
         probe_all_modules(
-            httpx_response=mock_response,
+            http_response=mock_response,
             url="https://example.com",
         )
     )
@@ -301,7 +296,6 @@ def test_derive_keyset_bad_private_key():
     assert result is None
 
 
-@respx.mock
 def test_probe_no_active_keys():
     """Probe returns empty when no active keys are available."""
     import unittest.mock as mock
@@ -312,21 +306,18 @@ def test_probe_no_active_keys():
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_request_exception():
     """Exception during individual key probe doesn't crash."""
-    call_count = 0
 
     def side_effect(request):
-        nonlocal call_count
-        call_count += 1
-        cookie_header = request.headers.get("cookie", "")
+        cookie_header = _cookie_value(request)
         if "LtpaToken2=" in cookie_header:
-            raise httpx.ReadTimeout("timeout")
-        return httpx.Response(302, text="", headers={"Location": "/login"})
+            raise RuntimeError("timeout")
+        return MockResponse(text="", status_code=302, headers={"Location": "/login"})
 
-    respx.get("https://websphere.example.com/ibm/console").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://websphere.example.com/ibm/console")
 
-    gp = LTPA_Token_Key()
+    gp = LTPA_Token_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://websphere.example.com/ibm/console"))
     assert len(results) == 0

--- a/tests/shiro_active_test.py
+++ b/tests/shiro_active_test.py
@@ -1,10 +1,28 @@
 import asyncio
 import base64
 import unittest.mock as mock
-import httpx
-import respx
+from blasthttp.mock import BlasthttpMock, MockResponse
 from badsecrets.base import yara_prefilter_scan, probe_all_modules, build_prefilter_text
 from badsecrets.modules.active.shiro_rememberme import Shiro_RememberMe_Key, _SERIALIZED_PRINCIPAL
+
+
+class FakeResponse:
+    """Duck-typed HTTP response for build_prefilter_text/probe_all_modules tests."""
+
+    def __init__(self, text="", headers=None, cookies=None, url=""):
+        self.text = text
+        self.headers = headers if headers is not None else {}
+        self.cookies = cookies if cookies is not None else {}
+        self.url = url
+
+
+def _cookie_value(req):
+    """Case-insensitive lookup of the Cookie header on a MockRequest."""
+    for k, v in req.headers.items():
+        if k.lower() == "cookie":
+            return v
+    return ""
+
 
 SHIRO_LOGIN_HTML = """
 <html>
@@ -48,13 +66,12 @@ def test_prefilter_miss():
 
 def test_build_prefilter_text():
     """build_prefilter_text includes headers and body."""
-    resp = httpx.Response(
-        200,
+    resp = FakeResponse(
         text="<html></html>",
         headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
-        request=httpx.Request("GET", "https://example.com"),
+        url="https://example.com",
     )
-    text = build_prefilter_text(httpx_response=resp)
+    text = build_prefilter_text(http_response=resp)
     assert "rememberMe=deleteMe" in text
     assert "<html></html>" in text
 
@@ -104,38 +121,25 @@ def test_encrypt_decrypt_roundtrip_gcm():
     assert pt == _SERIALIZED_PRINCIPAL
 
 
-@respx.mock
 def test_probe_default_key_found_cbc():
     """Default key accepted (no deleteMe) in CBC mode -> SecretFound."""
-    # Confirmation request (garbage cookie) -> deleteMe (confirms Shiro present)
-    respx.get("https://shiro.example.com/login").mock(
-        return_value=httpx.Response(
-            200,
-            text=SHIRO_LOGIN_HTML,
-            headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
-        )
-    )
-
-    call_count = 0
 
     def side_effect(request):
-        nonlocal call_count
-        call_count += 1
-        cookie_header = request.headers.get("cookie", "")
+        cookie_header = _cookie_value(request)
         if "rememberMe=1" in cookie_header:
             # Garbage cookie -> deleteMe (Shiro confirmation)
-            return httpx.Response(
-                200,
+            return MockResponse(
                 text=SHIRO_LOGIN_HTML,
                 headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
             )
-        else:
-            # Real encrypted cookie -> no deleteMe (key accepted!)
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML)
+        # Real encrypted cookie -> no deleteMe (key accepted!)
+        return MockResponse(text=SHIRO_LOGIN_HTML, status_code=200)
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     assert len(results) >= 1
     assert results[0]["type"] == "SecretFound"
@@ -144,49 +148,52 @@ def test_probe_default_key_found_cbc():
     assert "kPH+bIxk5D2deZiIxcaaaA==" in results[0]["secret"]
 
 
-@respx.mock
 def test_probe_key_rejected():
     """All keys rejected (deleteMe every time) -> no results."""
 
     def always_delete_me(request):
-        return httpx.Response(
-            200,
+        return MockResponse(
             text=SHIRO_LOGIN_HTML,
             headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+            status_code=200,
         )
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=always_delete_me)
+    bh = BlasthttpMock()
+    bh.add_callback(always_delete_me, url="https://shiro.example.com/login")
 
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_not_shiro():
     """Confirmation step fails (no deleteMe for garbage cookie) -> no probes sent."""
 
     def no_delete_me(request):
-        return httpx.Response(200, text="<html>Not Shiro</html>")
+        return MockResponse(text="<html>Not Shiro</html>", status_code=200)
 
-    respx.get("https://example.com/login").mock(side_effect=no_delete_me)
+    bh = BlasthttpMock()
+    bh.add_callback(no_delete_me, url="https://example.com/login")
 
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://example.com/login"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_connection_error():
     """Connection error -> no crash, no result."""
-    respx.get("https://shiro.example.com/login").mock(side_effect=httpx.ConnectError("Connection refused"))
 
-    gp = Shiro_RememberMe_Key()
+    def _err(req):
+        raise RuntimeError("Connection refused")
+
+    bh = BlasthttpMock()
+    bh.add_callback(_err, url="https://shiro.example.com/login")
+
+    gp = Shiro_RememberMe_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_probe_gcm_key_found():
     """CBC rejected but GCM accepted -> SecretFound with mode=GCM."""
     call_count = 0
@@ -196,32 +203,31 @@ def test_probe_gcm_key_found():
         call_count += 1
         if call_count == 1:
             # Confirmation: garbage cookie -> deleteMe
-            return httpx.Response(
-                200,
+            return MockResponse(
                 text=SHIRO_LOGIN_HTML,
                 headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
             )
-        elif call_count == 2:
+        if call_count == 2:
             # CBC attempt -> rejected
-            return httpx.Response(
-                200,
+            return MockResponse(
                 text=SHIRO_LOGIN_HTML,
                 headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
             )
-        else:
-            # GCM attempt -> accepted!
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML)
+        # GCM attempt -> accepted!
+        return MockResponse(text=SHIRO_LOGIN_HTML, status_code=200)
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     assert len(results) == 1
     assert results[0]["details"]["mode"] == "GCM"
     assert results[0]["details"]["is_default_key"] is True
 
 
-@respx.mock
 def test_probe_custom_key_found():
     """Custom key matches after default is rejected."""
     call_count = 0
@@ -230,34 +236,32 @@ def test_probe_custom_key_found():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            # Confirmation
-            return httpx.Response(
-                200,
+            return MockResponse(
                 text=SHIRO_LOGIN_HTML,
                 headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
             )
-        elif call_count <= 3:
+        if call_count <= 3:
             # Default key CBC + GCM -> rejected
-            return httpx.Response(
-                200,
+            return MockResponse(
                 text=SHIRO_LOGIN_HTML,
                 headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
             )
-        elif call_count == 4:
+        if call_count == 4:
             # Custom key CBC -> accepted!
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML)
-        else:
-            return httpx.Response(
-                200,
-                text=SHIRO_LOGIN_HTML,
-                headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
-            )
+            return MockResponse(text=SHIRO_LOGIN_HTML, status_code=200)
+        return MockResponse(
+            text=SHIRO_LOGIN_HTML,
+            headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+            status_code=200,
+        )
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
-    # Use a valid 16-byte key
     custom_key = base64.b64encode(b"\x00" * 16).decode()
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://shiro.example.com/login", custom_keys=[custom_key]))
     assert len(results) == 1
     assert results[0]["details"]["is_default_key"] is False
@@ -271,7 +275,6 @@ def test_probe_invalid_url():
     assert results == []
 
 
-@respx.mock
 def test_probe_with_http_client():
     """Probe uses provided http_client."""
     call_count = 0
@@ -280,26 +283,21 @@ def test_probe_with_http_client():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            return httpx.Response(
-                200,
+            return MockResponse(
                 text=SHIRO_LOGIN_HTML,
                 headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
             )
-        else:
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML)
+        return MockResponse(text=SHIRO_LOGIN_HTML, status_code=200)
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
-    async def run():
-        async with httpx.AsyncClient() as client:
-            gp = Shiro_RememberMe_Key(http_client=client)
-            return await gp.probe("https://shiro.example.com/login")
-
-    results = asyncio.run(run())
+    gp = Shiro_RememberMe_Key(http_client=bh)
+    results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     assert len(results) >= 1
 
 
-@respx.mock
 def test_probe_all_modules_integration():
     """Full flow: response with Shiro headers -> prefilter -> probe -> result."""
     call_count = 0
@@ -308,27 +306,27 @@ def test_probe_all_modules_integration():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            return httpx.Response(
-                200,
+            return MockResponse(
                 text=SHIRO_LOGIN_HTML,
                 headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
             )
-        else:
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML)
+        return MockResponse(text=SHIRO_LOGIN_HTML, status_code=200)
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
-    mock_response = httpx.Response(
-        200,
+    mock_response = FakeResponse(
         text=SHIRO_LOGIN_HTML,
         headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
-        request=httpx.Request("GET", "https://shiro.example.com/login"),
+        url="https://shiro.example.com/login",
     )
 
     results = asyncio.run(
         probe_all_modules(
-            httpx_response=mock_response,
+            http_response=mock_response,
             url="https://shiro.example.com/login",
+            http_client=bh,
         )
     )
     assert len(results) >= 1
@@ -338,18 +336,13 @@ def test_probe_all_modules_integration():
     assert results[0]["description"]["severity"] == "CRITICAL"
 
 
-@respx.mock
 def test_probe_all_modules_no_prefilter_match():
     """Unrelated response -> no prefilter match -> no probes fired."""
-    mock_response = httpx.Response(
-        200,
-        text=UNRELATED_HTML,
-        request=httpx.Request("GET", "https://example.com"),
-    )
+    mock_response = FakeResponse(text=UNRELATED_HTML, url="https://example.com")
 
     results = asyncio.run(
         probe_all_modules(
-            httpx_response=mock_response,
+            http_response=mock_response,
             url="https://example.com",
         )
     )
@@ -363,40 +356,47 @@ def test_description():
     assert desc["severity"] == "CRITICAL"
 
 
-@respx.mock
 def test_probe_resource_file_missing():
     """Missing resource file doesn't crash — falls back to default key."""
 
     def side_effect(request):
-        cookie_header = request.headers.get("cookie", "")
+        cookie_header = _cookie_value(request)
         if "rememberMe=1" in cookie_header:
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML, headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"})
-        return httpx.Response(200, text=SHIRO_LOGIN_HTML)
+            return MockResponse(
+                text=SHIRO_LOGIN_HTML,
+                headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
+            )
+        return MockResponse(text=SHIRO_LOGIN_HTML, status_code=200)
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     with mock.patch.object(gp, "load_resources", side_effect=FileNotFoundError):
         results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     assert len(results) >= 1
     assert results[0]["details"]["is_default_key"] is True
 
 
-@respx.mock
 def test_probe_default_key_not_in_resources():
     """When resource file keys don't include default, default is prepended."""
 
     def side_effect(request):
-        cookie_header = request.headers.get("cookie", "")
+        cookie_header = _cookie_value(request)
         if "rememberMe=1" in cookie_header:
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML, headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"})
-        return httpx.Response(200, text=SHIRO_LOGIN_HTML)
+            return MockResponse(
+                text=SHIRO_LOGIN_HTML,
+                headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
+            )
+        return MockResponse(text=SHIRO_LOGIN_HTML, status_code=200)
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
-    # Resource file returns a key that's NOT the default
     other_key = base64.b64encode(b"\x00" * 16).decode()
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     with mock.patch.object(gp, "load_resources", return_value=[f"{other_key}\n"]):
         results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     # Default key is tried first and accepted
@@ -404,27 +404,34 @@ def test_probe_default_key_not_in_resources():
     assert results[0]["details"]["is_default_key"] is True
 
 
-@respx.mock
 def test_probe_invalid_key_length():
     """Key that decodes to non-AES length is skipped."""
 
     def side_effect(request):
-        cookie_header = request.headers.get("cookie", "")
+        cookie_header = _cookie_value(request)
         if "rememberMe=1" in cookie_header:
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML, headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"})
-        return httpx.Response(200, text=SHIRO_LOGIN_HTML, headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"})
+            return MockResponse(
+                text=SHIRO_LOGIN_HTML,
+                headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
+            )
+        return MockResponse(
+            text=SHIRO_LOGIN_HTML,
+            headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+            status_code=200,
+        )
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
     # 15 bytes is not a valid AES key length (need 16, 24, or 32)
     bad_key = base64.b64encode(b"\x00" * 15).decode()
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     with mock.patch.object(gp, "load_resources", return_value=[f"{bad_key}\n"]):
         results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     assert len(results) == 0
 
 
-@respx.mock
 def test_try_key_exception():
     """Exception in _try_key doesn't crash probe."""
     call_count = 0
@@ -433,11 +440,16 @@ def test_try_key_exception():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            return httpx.Response(200, text=SHIRO_LOGIN_HTML, headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"})
-        raise httpx.ReadTimeout("timeout")
+            return MockResponse(
+                text=SHIRO_LOGIN_HTML,
+                headers={"Set-Cookie": "rememberMe=deleteMe; Path=/"},
+                status_code=200,
+            )
+        raise RuntimeError("timeout")
 
-    respx.get("https://shiro.example.com/login").mock(side_effect=side_effect)
+    bh = BlasthttpMock()
+    bh.add_callback(side_effect, url="https://shiro.example.com/login")
 
-    gp = Shiro_RememberMe_Key()
+    gp = Shiro_RememberMe_Key(http_client=bh)
     results = asyncio.run(gp.probe("https://shiro.example.com/login"))
     assert len(results) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -3,20 +3,6 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "anyio"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
-]
-
-[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -29,13 +15,22 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "badsecrets"
 source = { editable = "." }
 dependencies = [
+    { name = "blasthttp" },
     { name = "colorama" },
     { name = "django" },
     { name = "flask-unsign" },
-    { name = "httpx" },
     { name = "pycryptodome" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "yara-python" },
@@ -45,17 +40,17 @@ dependencies = [
 dev = [
     { name = "mock" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
-    { name = "respx" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "blasthttp", specifier = ">=0.5.1" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "django", specifier = ">=4.1.2,<6.0.0" },
     { name = "flask-unsign", specifier = ">=1.2.1" },
-    { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "pycryptodome", specifier = ">=3.21.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.6.0" },
     { name = "yara-python", specifier = ">=4.2.0" },
@@ -65,9 +60,67 @@ requires-dist = [
 dev = [
     { name = "mock", specifier = ">=5.1.0" },
     { name = "pytest", specifier = ">=8.3.4,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21,<2.0" },
     { name = "pytest-cov", specifier = ">=6.1.1,<8.0.0" },
     { name = "pytest-mock", specifier = ">=3.10.0" },
-    { name = "respx", specifier = ">=0.21,<1.0" },
+]
+
+[[package]]
+name = "blasthttp"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/743522a80b4638f0bd62d55d5e650c1397b311916c24d7581c00b1f2b7db/blasthttp-0.5.1.tar.gz", hash = "sha256:5aa7004eb96cc7be9677bf70641e142c000dd1cd16f63783d1eeec27ac165572", size = 137955, upload-time = "2026-05-07T18:29:12.905Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/2a/63176160b883a0e54c3083f434fe66673381352b0fd3ea775065ae53f1c5/blasthttp-0.5.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:95418e10c61bb8a34c75fc22ff841dc7ca07dfe28ab242db9eef408a98002abb", size = 4755999, upload-time = "2026-05-07T18:27:33.187Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/17/5af611bb6c37548c3de514ba74258db61cdde969991e52bb0c688a0785e0/blasthttp-0.5.1-cp310-cp310-manylinux_2_28_armv7l.whl", hash = "sha256:636281fec4a237c5f388957ea4f12bbf8f83f441390c5781653ee95fc9203d20", size = 4060750, upload-time = "2026-05-07T18:27:43.913Z" },
+    { url = "https://files.pythonhosted.org/packages/57/17/6eb6d7c6b8ae201ef0276d2ec6c6ecc24973e0e2c61131cd83641c8b840d/blasthttp-0.5.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:782b58702c565254f3c04d6abd526b982c1c37f2e67b91e909e648db942a494a", size = 4650132, upload-time = "2026-05-07T18:28:13.893Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e5/9f28983f6f3c3eeb8bd64e0a71b11e729909c69a5ff7fc6e181036e0bd79/blasthttp-0.5.1-cp310-cp310-manylinux_2_28_ppc64le.whl", hash = "sha256:fe61ff9488c1b5e861bdd34b05891a83b137ec15bb9dbf3299e550a8a02aabdf", size = 4662736, upload-time = "2026-05-07T18:27:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/33/221616e23c829ada6bada7aa7103afea8f93b905a98576cac17881150475/blasthttp-0.5.1-cp310-cp310-manylinux_2_28_s390x.whl", hash = "sha256:4068e53d2b7a99909ecbcb3d636439f8eecce2ef2c8605f63bba51848a97f85f", size = 4266449, upload-time = "2026-05-07T18:28:04.038Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/addfad565f765d7c1ff78b16862e4698056de1ac046c87ea2e309ee45cd7/blasthttp-0.5.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d9ff490b8dd7b7ecb8372308d08091cd0ef495dc67b3af1420b38174b9161946", size = 4403803, upload-time = "2026-05-07T18:28:23.814Z" },
+    { url = "https://files.pythonhosted.org/packages/47/04/fb2d63d12d067767a1b0ba2c505e76b26cea62f07644b2c90d6f2b0f721d/blasthttp-0.5.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:94c216d0ec4726b07935944a1fa4c7a38042130c89d7cb892d0d79753b793325", size = 5046967, upload-time = "2026-05-07T18:28:33.161Z" },
+    { url = "https://files.pythonhosted.org/packages/84/30/dbcd4d7617ba28da4f2fe8eccdbfdb5127857163d3c533dcab8546911c19/blasthttp-0.5.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:4af762a68e17516b912a21ea7639fb294f70c81033a86fba927294eae37cc18a", size = 4364595, upload-time = "2026-05-07T18:28:43.383Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8c/c4625cf90cc8b3aa6dc8cd06294133b415ce134d47138e2deacad3ac16a2/blasthttp-0.5.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1d3f26b8a43b3c2cf99dab640cbc8abd6257199c72e3f302959bd9ad27feca40", size = 4782547, upload-time = "2026-05-07T18:28:54.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b8/7461bc2396f501b7c8273285a28134200fa1ac106e5faea0e4d6a984a0fc/blasthttp-0.5.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:38f2f573a3e3d6efaf83266e7ac5ee54b272287b74e9e539020f6b77bf9cb2a2", size = 4750218, upload-time = "2026-05-07T18:29:03.441Z" },
+    { url = "https://files.pythonhosted.org/packages/34/88/1fc3e0a9fea99ab101eb57c31f639139d5eed7be032f4f2aa9370a65f76f/blasthttp-0.5.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bcddfa279c301ae6ee0b2753389db896a7bbc08d012f41e2c9ef97814e73c3f6", size = 4752484, upload-time = "2026-05-07T18:27:35.287Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7e/5b75a6d28fcc8fc5c7076960909ff4cbdd075724e1f980965c00f7973832/blasthttp-0.5.1-cp311-cp311-manylinux_2_28_armv7l.whl", hash = "sha256:b916982c34aed04e0e6ba13832c7b44ee924e989751f9bb988728f53ea7c6e42", size = 4057857, upload-time = "2026-05-07T18:27:45.652Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/9c566ea8a176f404d7f715b15c04fdd9ce53f7986342c924cfca7b7f92e0/blasthttp-0.5.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:48cb954a104c2a84f3ea8fecd819ce2c2cff797b51cfb24ac00286c5e1ecb150", size = 4645668, upload-time = "2026-05-07T18:28:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ac/c8c9e622e0fcf9a8843a1f66cbb1467e3b6ad789051a7ce2f2ebade1fde0/blasthttp-0.5.1-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:b256681548199fb0a7f9bf317592a394b927d5769602dd4b206ee59bfde25010", size = 4658128, upload-time = "2026-05-07T18:27:55.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ce/e4ea0b8a068c5e86cd461473066a0e8e3e6c4556a96edf58d5a7e9511975/blasthttp-0.5.1-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:89b6b5c3e5603b34a570db331d5fba0d3651e347d3ff87ecae9e7dc59a296a0b", size = 4264160, upload-time = "2026-05-07T18:28:06.032Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dc/01fd77bdd401d4375e6407a06e1e2c7b6860e8813c67ab9977f016663763/blasthttp-0.5.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:257520128a4009f577b63de72b6bee47e37f06b669a503f74d7de868fc04c186", size = 4402098, upload-time = "2026-05-07T18:28:25.626Z" },
+    { url = "https://files.pythonhosted.org/packages/96/33/103f121023609d4b75123e019cdcfc2aee3ebb87518db93c2fcb4de6688c/blasthttp-0.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b70cc21ffb61a8bef833ec4e94fe82daef7aa449cf5638bb44987d6b5b8145e1", size = 5044456, upload-time = "2026-05-07T18:28:35.141Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2f/9f4c93d6ec8ecd75e5218cbf9b8fbe5addb9e031f66806045462366180cd/blasthttp-0.5.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:89cc27ac11495ad123f31ebe4c9c750a54782bf225375305c0a25637a4b5a40e", size = 4358153, upload-time = "2026-05-07T18:28:45.15Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a0/4b5b9ba163d792f87ce1dc15180c4d49b8ccd32bca9689d0c2dfa32cef5b/blasthttp-0.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a0f311998dfacdbb6cc540929471edbad7e943ba03b0721338fc187b850aa870", size = 4777624, upload-time = "2026-05-07T18:28:55.888Z" },
+    { url = "https://files.pythonhosted.org/packages/63/76/d9b538467b90b0e04a50db8193717ce414e40d78250ae5c0ff6e9562cbdd/blasthttp-0.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20c7a2086c0bae72ad7c12bdbe04f75258cbb49dc036eaf7c00834a625e0d0ee", size = 4746331, upload-time = "2026-05-07T18:29:05.591Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d3/8829983cb5be11320f0913877a49771827ab3c0b23a75b49912af96e89be/blasthttp-0.5.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e220270707d5eeab95adc0514d7bc6615b80c7d2e4af6f2236ee731ca3c90f88", size = 4753416, upload-time = "2026-05-07T18:27:37.3Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4c/3dde5c943fefe6463fe0056f2e8fae9f4cedbee664f28cb882cb9060a88c/blasthttp-0.5.1-cp312-cp312-manylinux_2_28_armv7l.whl", hash = "sha256:8fc60f3edf95766cf715d26d0ce2a87a10d802431324047964a478484bcbbf39", size = 4056173, upload-time = "2026-05-07T18:27:47.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d0/adb42760fd3c634186a21c2c3ab016d098187b0fa7867df804a593b118e9/blasthttp-0.5.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:503a5324c746db7522665ec14fa6b2b00fa32e854a526c42a80719032fde1195", size = 4646538, upload-time = "2026-05-07T18:28:17.582Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ec/2ca18456e012b545b5fec48ed1234d3fedf9cf9c89efec7e9848f4e06472/blasthttp-0.5.1-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:f141807b927bee9c9e6fff078027d625ba7d375d380bb79de3a69b7cd32370c1", size = 4650786, upload-time = "2026-05-07T18:27:57.896Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a8/6d8e19ebafbca3467b1d8655e3144d2cdf97dcf524f0029002b0e5666b10/blasthttp-0.5.1-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:6e116205aea16b8a772dacc9b28cb49a0e3ff6de01ed5f987c4381cb4ea2373d", size = 4271821, upload-time = "2026-05-07T18:28:07.918Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4d/e9638afa76dadb50e6204d8ba19493752e4257a4e54396082abba457baa6/blasthttp-0.5.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3190bc1605af2a3e9bfce73825a6c2892548173376c3cfd66fdfbc46349fd295", size = 4400583, upload-time = "2026-05-07T18:28:27.438Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/8b5821db29f000a24ff83fa02c937a89f95a990ed85abfbf65d73163bf41/blasthttp-0.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:34fb35ff5c755d70ab195f6d1bf6b19f82ec1c9d45c264ea0688ba6e1d7b187f", size = 5045394, upload-time = "2026-05-07T18:28:37.056Z" },
+    { url = "https://files.pythonhosted.org/packages/69/a0/b330f4cd0b422199a6dc8d2d46e18f971df0542d34ce59758dbe323f4f94/blasthttp-0.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:77c8a11a6d2101ef3a9b3ddb1d6dc35188967cec384566be6e375940221ad565", size = 4354081, upload-time = "2026-05-07T18:28:48.069Z" },
+    { url = "https://files.pythonhosted.org/packages/26/8d/408beb779ee330f0fcf38016656034ddb943d620c8fe7c5c2aaed98c4096/blasthttp-0.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5e0603e612ae91579cf437ed9b2014451cfac73f45bf0d21c399197238944bb9", size = 4773321, upload-time = "2026-05-07T18:28:57.629Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c0/3b1cde8fb0b93c7fa493a399d9babccc2117a06423955872e716eb748bb0/blasthttp-0.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b7ced43ddcf436a85cc2c33c7e7895d324fc6b708a6098e122d5246bc5c2a7c", size = 4740837, upload-time = "2026-05-07T18:29:07.454Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6c/fa8bfa5d1932fac65802904cd9630a8863593f884fe0e0c4924e54ef3402/blasthttp-0.5.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:45d01055a1473b22dd460881f07ad4dd9fb64cd8044c391475540c761a490fda", size = 4750786, upload-time = "2026-05-07T18:27:39.329Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1e/06d57776db6ae8078acc51aa0e71b59c4316c1a2ec62c4c34418aa54f073/blasthttp-0.5.1-cp313-cp313-manylinux_2_28_armv7l.whl", hash = "sha256:2e9951422b43938059d87ea17594f81a2fe3be932e53c63a9670cd64465c8c7e", size = 4055319, upload-time = "2026-05-07T18:27:49.413Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a6/9c3c09b6d214ed6b1286156b3209ec39770fc25879f0911c032fdb92de17/blasthttp-0.5.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:9582a8ba5f2dd0fb140c6e2a8cbdee0a9a42171636fa4963e40bdc9370db8592", size = 4650611, upload-time = "2026-05-07T18:28:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/4cadba4c58fe9adcba405da6ec882a42ce76fe2a158c3d61c49f0a7a75bf/blasthttp-0.5.1-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:1f014f2a540f02988df63db363dd59ea0a755becdc85e7a4e89c364e273532c3", size = 4656848, upload-time = "2026-05-07T18:27:59.929Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/52/eeea501e966c27b0f7931ff1fa81efdefa877dacbe273a18dfd93940faed/blasthttp-0.5.1-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:5b36ed6a395e70ec5bd0b9d751f2b3f27f2ca47e5d444cb2d0bd831f0c0f2089", size = 4269300, upload-time = "2026-05-07T18:28:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/71/a6/ef585df6a3704e1c0adc42fd6d1fe9c5de1e3d7b4faf940268ea036c6d77/blasthttp-0.5.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e3f189ccf8b96b83ad786ae3130a5f792edf8947b58875a88d556c7150b49bf1", size = 4398860, upload-time = "2026-05-07T18:28:29.363Z" },
+    { url = "https://files.pythonhosted.org/packages/03/67/cdedc3ee88728486f2214bf8784e71f96d5c05426c58988002b9922e2813/blasthttp-0.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8cc079bd171452bab6e639a20ac9d946c2145e94fccde8750e9516ac988527ef", size = 5042568, upload-time = "2026-05-07T18:28:39.091Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9c/bc0d90bb71a2b1b86bee746ce083e06e70d35e91774d15254c959ab21ecf/blasthttp-0.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:792bb93ae83211ce6effd969b318883e6df141ee32642c5659cbbf7521357402", size = 4353688, upload-time = "2026-05-07T18:28:50.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6a/e0cf6f11b35542cf6a621b17630071c6d384eac021712a2792c104c1a700/blasthttp-0.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:dd2b8a4f7da0a1f01b9b7f8285b7206097b0fdec28e66fd0f227cab382434b87", size = 4776869, upload-time = "2026-05-07T18:28:59.56Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/767ef4b4449c144844dbdabae8c8c3543566bab86a8988e7bf7605d8f6b9/blasthttp-0.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:31d3fdce0dec44cf90e1e7c42dea28bc5a608d4f0ec9957d6daae1d17a85a34e", size = 4740866, upload-time = "2026-05-07T18:29:09.474Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b8/55773b2c131d62ccd0da80df1d14c89abe2400e48d14965f64d5bc24dd67/blasthttp-0.5.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7e63602c657d991a04c0f9cd07bf79e07b3653b2f8d463677fc3b400100e89a1", size = 4751678, upload-time = "2026-05-07T18:27:41.883Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/04/56645c45dbdbe5776d26c752fe5a6c4b78a79c257ee72d6800e7c0a7517e/blasthttp-0.5.1-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:7830256ad0f7306fa6c124bcf151a60f1be3d052f281c75687d3c4c31483505b", size = 4053899, upload-time = "2026-05-07T18:27:51.345Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/a9cd12d8f511da6f88c31da2a620e65704156fda5b081dc2e32259b31db4/blasthttp-0.5.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:99b2f6005a32f9bac360843bf56ccb3670e3a514d12089484161eb8f4719476b", size = 4646514, upload-time = "2026-05-07T18:28:21.852Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/ab280c9b32e2cc69a9985a52705920dc94d45c7b4fc864e040b38d07d0b7/blasthttp-0.5.1-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:3e8482467a5f3eb8ebc2f126962469c2879527a2e12f19d3c98c1a08bcb4e52a", size = 4650094, upload-time = "2026-05-07T18:28:01.841Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/45/613a32c54607340c607ffd39f902fd86aa6fe51be3e6a2df9ef54639251a/blasthttp-0.5.1-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:caa19201bacf87a85baf66e0d5d4c50c99be6d04794c6319585a93802d79b407", size = 4268936, upload-time = "2026-05-07T18:28:12.078Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3e/e5283d9f474aa781031b7998915aa5a06ff06c3862b57ba3a5a414df07b7/blasthttp-0.5.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:3846854fb99b71fa47b34aedd81100fc6c2c6772fc0d39b9fb36f05538d17262", size = 4401565, upload-time = "2026-05-07T18:28:31.151Z" },
+    { url = "https://files.pythonhosted.org/packages/80/94/778114a7b4f1dd55d098f07a6525dfaedb1c26668d50a99b10edae7a8b65/blasthttp-0.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6da8900885e8136de8ddee17fc7854cee2483cebce49f356e99dcaf59e8dc7c7", size = 5044853, upload-time = "2026-05-07T18:28:41.058Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/62/bbfc224d7991e3aea67d31a579e77e4b1da16bb758dcc3cf7e1e6c71d6f2/blasthttp-0.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ee3bb7327110943e1d0c2c4fe1610a38a83615bff36d0f1b3beebffe1b0e135c", size = 4351539, upload-time = "2026-05-07T18:28:51.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1c/47b56406842e69d1141d786d27d82b94efa223e1e56d20a4ecc5d09bea62/blasthttp-0.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4d81941032f724243a784503a2a8cd0190974932e16ec5d8f65cc2c593de1d09", size = 4775145, upload-time = "2026-05-07T18:29:01.519Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f7/6b75a895c9efb6443a5cf401b3f8fd8e9b40425c1fe8abeb552a56e71fb6/blasthttp-0.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ec5ff94b70c3a5ec11b19a20235d07f7851dee459084063c0ab13ecd6a7a46ea", size = 4742883, upload-time = "2026-05-07T18:29:11.231Z" },
 ]
 
 [[package]]
@@ -534,43 +587,6 @@ wheels = [
 ]
 
 [[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -810,6 +826,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -848,18 +878,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
-]
-
-[[package]]
-name = "respx"
-version = "0.23.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace httpx with blasthttp throughout: library (`base.py` + 3 active modules), all 4 CLI scripts (`cli.py`, `telerik_knownkey.py`, `blacklist3r.py`, `symfony_knownkey.py`), and all 12 test files.
- `base.py`: rename `httpx_response=` → `http_response=` (duck-typed); add `http_client=` kwarg to `probe_all_modules` so callers can share/inject a client.
- New `tests/conftest.py` exposes a `bh_mock` fixture (fresh `BlasthttpMock` per test) with `BlastHTTP` patched on each CLI script.
- Drop `httpx` and `respx`; add `blasthttp>=0.5.1` and `pytest-asyncio`.

## bbot compatibility

`carve_all_modules(body=, headers=, cookies=, url=, custom_resource=)` is unchanged — bbot's existing call site keeps working. Active modules accept `http_client=` so bbot can share its blasthttp client when wired through.

## Test plan

- [x] All 456 tests pass locally on Python 3.14
- [x] `uvx ruff format --check .` and `uvx ruff check .` pass
- [ ] CI green across 3.10–3.14