### PR TITLE
surface IdentifyOnly results from cookies and manual product mode

### DIFF
--- a/badsecrets/base.py
+++ b/badsecrets/base.py
@@ -162,7 +162,21 @@ class BadsecretsBase:
 
         # Don't report an IdentifyOnly result if we have a SecretFound result for the same 'product'
         secret_found_results = {d["product"] for d in results if d["type"] == "SecretFound"}
-        return [d for d in results if not (d["type"] == "IdentifyOnly" and d["product"] in secret_found_results)]
+        results = [d for d in results if not (d["type"] == "IdentifyOnly" and d["product"] in secret_found_results)]
+
+        # Within a single module, collapse multiple IdentifyOnly hits into one —
+        # if a module recognizes 4 cookies on a response without cracking any,
+        # the user just needs to know "this product is here" once. Keep the
+        # first as the representative product value.
+        seen_identify_only = False
+        deduped = []
+        for d in results:
+            if d["type"] == "IdentifyOnly":
+                if seen_identify_only:
+                    continue
+                seen_identify_only = True
+            deduped.append(d)
+        return deduped
 
     def _carve_body(self, body, cookies, headers, **kwargs):
         """Extract secrets from HTML body text. Override in subclasses for custom body carving."""

--- a/badsecrets/base.py
+++ b/badsecrets/base.py
@@ -116,8 +116,12 @@ class BadsecretsBase:
                 if r:
                     r["type"] = "SecretFound"
                     r["product"] = v
-                    r["location"] = "cookies"
-                    results.append(r)
+                elif self.validate_carve and self.identify(v):
+                    r = {"type": "IdentifyOnly", "product": v, "hashcat": self.get_hashcat_commands(v)}
+                else:
+                    continue
+                r["location"] = "cookies"
+                results.append(r)
 
         if headers and "headers" in self.carve_locations:
             for header_value in headers.values():
@@ -374,19 +378,46 @@ def hashcat_all_modules(product, detecting_module=None, *args):
 
 
 def check_all_modules(*args, **kwargs):
+    """Run every passive module against the supplied product(s).
+
+    Returns a list of result dicts (each tagged ``type=SecretFound`` or
+    ``type=IdentifyOnly``), or None if nothing matched. Mirrors the shape
+    of ``carve_all_modules``: SecretFound results come from
+    ``check_secret``; IdentifyOnly results come from a module's
+    ``identify_regex`` matching the value but no known secret being found.
+    """
+    results = []
     for m in _passive_subclasses():
         x = m(custom_resource=kwargs.get("custom_resource"))
         r = x.check_secret(*args[0 : x.check_secret_args])
         if r:
+            r["type"] = "SecretFound"
             r["detecting_module"] = m.__name__
             r["description"] = x.get_description()
-
-            # allow the module to provide an amended product, if needed
             if "product" not in r:
                 r["product"] = args[0]
             r["location"] = "manual"
-            return r
-    return None
+            results.append(r)
+        elif x.validate_carve and x.identify(args[0]):
+            # Hashcat is intentionally left unset; callers (e.g. the CLI) populate
+            # it via hashcat_all_modules() so the format matches what
+            # print_hashcat_results expects.
+            results.append(
+                {
+                    "type": "IdentifyOnly",
+                    "product": args[0],
+                    "hashcat": None,
+                    "detecting_module": m.__name__,
+                    "description": x.get_description(),
+                    "location": "manual",
+                }
+            )
+
+    # If ANY module produced a SecretFound, suppress ALL IdentifyOnly results —
+    # an actionable cracked secret outranks every recognition-only candidate.
+    if any(r["type"] == "SecretFound" for r in results):
+        results = [r for r in results if r["type"] == "SecretFound"]
+    return results or None
 
 
 def carve_all_modules(**kwargs):
@@ -413,6 +444,10 @@ def carve_all_modules(**kwargs):
             for r in r_list:
                 r["detecting_module"] = m.__name__
                 results.append(r)
+
+    # If ANY module produced a SecretFound, suppress ALL IdentifyOnly results.
+    if any(r["type"] == "SecretFound" for r in results):
+        results = [r for r in results if r["type"] == "SecretFound"]
     if results:
         return results
 

--- a/badsecrets/examples/cli.py
+++ b/badsecrets/examples/cli.py
@@ -523,18 +523,29 @@ def main():
     else:
         if args.debug and not json_mode:
             print_status(f"[DEBUG] Checking product(s): {args.product}", color="blue")
-        x = check_all_modules(*args.product, custom_resource=custom_resource)
+        results = check_all_modules(*args.product, custom_resource=custom_resource)
         if args.debug and not json_mode:
-            if x:
-                print_status(f"[DEBUG] Match found by module: {x.get('detecting_module', 'unknown')}", color="blue")
+            if results:
+                modules_hit = {r["detecting_module"] for r in results}
+                print_status(f"[DEBUG] Match found by module(s): {', '.join(modules_hit)}", color="blue")
             else:
                 print_status("[DEBUG] No match from any module", color="blue")
-        if x:
+        if results:
             if json_mode:
-                print(json_module.dumps(x))
+                print(json_module.dumps(results))
             else:
-                report = ReportSecret(x)
-                report.report()
+                for r in results:
+                    if r["type"] == "SecretFound":
+                        report = ReportSecret(r)
+                    else:
+                        if not args.no_hashcat and r.get("hashcat") is None:
+                            hashcat_candidates = hashcat_all_modules(
+                                r["product"], detecting_module=r["detecting_module"]
+                            )
+                            if hashcat_candidates:
+                                r["hashcat"] = hashcat_candidates
+                        report = ReportIdentify(r)
+                    report.report()
         else:
             if not json_mode:
                 print_status("No secrets found :(", color="red")

--- a/badsecrets/examples/cli.py
+++ b/badsecrets/examples/cli.py
@@ -446,6 +446,17 @@ def main():
             if r_list:
                 all_passive_results.extend(r_list)
 
+        # One IdentifyOnly per module across all fetches; SecretFound never deduped.
+        seen_identify_modules = set()
+        deduped = []
+        for r in all_passive_results:
+            if r["type"] == "IdentifyOnly":
+                if r["detecting_module"] in seen_identify_modules:
+                    continue
+                seen_identify_modules.add(r["detecting_module"])
+            deduped.append(r)
+        all_passive_results = deduped
+
         if args.debug and not json_mode:
             if all_passive_results:
                 modules_hit = {r["detecting_module"] for r in all_passive_results}

--- a/badsecrets/modules/passive/laravel_signedcookies.py
+++ b/badsecrets/modules/passive/laravel_signedcookies.py
@@ -23,7 +23,10 @@ class LaravelSignedCookies(BadsecretsBase):
             return decrypted
         return None
 
-    identify_regex = re.compile(r"eyJ(?:[\w-])*")
+    # Laravel-encrypted cookies always start with the base64 of `{"iv":` (= `eyJpdi`).
+    # Anchoring on this prefix avoids false-positive overlap with JWTs (`eyJhbGc…`)
+    # and other arbitrary base64 blobs.
+    identify_regex = re.compile(r"^eyJpdi[\w-]+")
     description = {"product": "Laravel Signed Cookie", "secret": "Laravel APP_KEY", "severity": "HIGH"}
     carve_locations = ("cookies",)
 

--- a/badsecrets/modules/passive/ltpa_token.py
+++ b/badsecrets/modules/passive/ltpa_token.py
@@ -24,8 +24,12 @@ def _des3_ecb_decrypt(key_24, data):
 
 
 class LTPA_Token(BadsecretsBase):
-    # Base64 pattern — LTPA tokens are typically 100+ bytes base64-encoded
-    identify_regex = re.compile(r"^(?:[A-Za-z0-9+/]{4}){16,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+    # Base64 pattern — LTPA tokens are typically 100+ bytes base64-encoded.
+    # The negative lookahead excludes `eyJ`-prefixed values (Laravel-encrypted
+    # cookies, JWTs, Flask sessions) which are AES-encrypted random bytes for
+    # LTPA but always start with `eyJ` (base64 of `{"`) for the JSON-shaped
+    # formats; this prevents cross-module false positives.
+    identify_regex = re.compile(r"^(?!eyJ)(?:[A-Za-z0-9+/]{4}){16,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
     description = {"product": "IBM WebSphere LTPA", "secret": "LTPA Encryption Key", "severity": "HIGH"}
     carve_locations = ("cookies",)
 

--- a/badsecrets/modules/passive/peoplesoft_pstoken.py
+++ b/badsecrets/modules/passive/peoplesoft_pstoken.py
@@ -1,11 +1,16 @@
+import re
 import zlib
 import base64
 import hashlib
-from badsecrets.base import BadsecretsBase, generic_base64_regex
+from badsecrets.base import BadsecretsBase
 
 
 class Peoplesoft_PSToken(BadsecretsBase):
-    identify_regex = generic_base64_regex
+    # Long base64; exclude the `eyJ` prefix so this doesn't fire on Laravel /
+    # JWT / Flask cookies which all start with base64(`{"`).
+    identify_regex = re.compile(
+        r"^(?!eyJ)(?:[A-Za-z0-9+\/]{4}){8,}(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2})$"
+    )
     description = {"product": "Peoplesoft PS_TOKEN", "secret": "Peoplesoft Secret", "severity": "HIGH"}
 
     def peoplesoft_load(self, PS_TOKEN_B64):

--- a/badsecrets/modules/passive/shiro_rememberme.py
+++ b/badsecrets/modules/passive/shiro_rememberme.py
@@ -10,7 +10,10 @@ JAVA_SERIALIZATION_MAGIC = b"\xac\xed\x00\x05"
 
 class Shiro_RememberMe(BadsecretsBase):
     # Base64 pattern, minimum 44 chars (32 bytes = 16 IV + 16 ciphertext minimum)
-    identify_regex = re.compile(r"^(?:[A-Za-z0-9+/]{4}){11,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
+    # Exclude the `eyJ` prefix to avoid matching Laravel/JWT/Flask cookies that
+    # also fit a generic long-base64 pattern. Real Shiro rememberMe cookies are
+    # AES-encrypted random bytes and don't legitimately start with `eyJ`.
+    identify_regex = re.compile(r"^(?!eyJ)(?:[A-Za-z0-9+/]{4}){11,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
     description = {"product": "Apache Shiro", "secret": "RememberMe AES Key", "severity": "CRITICAL"}
     carve_locations = ("cookies",)
 

--- a/badsecrets/modules/passive/telerik_encryptionkey.py
+++ b/badsecrets/modules/passive/telerik_encryptionkey.py
@@ -16,7 +16,10 @@ telerik_hardcoded_salt = [58, 84, 91, 25, 10, 34, 29, 68, 60, 88, 44, 51, 1]
 
 
 class Telerik_EncryptionKey(BadsecretsBase):
-    identify_regex = re.compile(r"^(?:[A-Za-z0-9+\/=%]{32,})$")
+    # Exclude the `eyJ` prefix to avoid matching Laravel/JWT/Flask cookies
+    # that also satisfy a generic long-base64 pattern. Telerik dialog
+    # parameters are AES-encrypted random bytes and don't start with `eyJ`.
+    identify_regex = re.compile(r"^(?!eyJ)(?:[A-Za-z0-9+\/=%]{32,})$")
     yara_carve_pattern = r"\"SerializedParameters\":\"[A-Za-z0-9+\/=]{32,500}"
     description = {
         "product": "Telerik DialogParameters",

--- a/badsecrets/modules/passive/telerik_hashkey.py
+++ b/badsecrets/modules/passive/telerik_hashkey.py
@@ -8,7 +8,8 @@ from badsecrets.base import BadsecretsBase
 
 
 class Telerik_HashKey(BadsecretsBase):
-    identify_regex = re.compile(r"^(?:[A-Za-z0-9+\/=%]{32,})$")
+    # Exclude the `eyJ` prefix; see telerik_encryptionkey for rationale.
+    identify_regex = re.compile(r"^(?!eyJ)(?:[A-Za-z0-9+\/=%]{32,})$")
     yara_carve_pattern = r"\"SerializedParameters\":\"[A-Za-z0-9+\/=]{32,500}"
     description = {
         "product": "Telerik DialogParameters",

--- a/tests/all_modules_test.py
+++ b/tests/all_modules_test.py
@@ -36,15 +36,19 @@ negative_tests = [
 
 
 def test_check_all():
-    # Confirm each of the examples produced a positive result
+    # Confirm each of the examples produced a SecretFound result
     for test in tests:
         r = check_all_modules(test)
         assert r
+        assert any(d["type"] == "SecretFound" for d in r)
 
-    # verify various types of non-matching inputs do not produce errors or false positives
+    # verify various types of non-matching inputs do not produce SecretFound
+    # (IdentifyOnly hits are allowed — e.g. a JWT-shaped string with a bad signature
+    # is legitimately identified as a JWT, just not crackable.)
     for negative_test in negative_tests:
         r = check_all_modules(negative_test)
-        assert not r
+        if r:
+            assert all(d["type"] == "IdentifyOnly" for d in r)
 
 
 aspnet_viewstate_sample = """
@@ -120,7 +124,10 @@ def test_carve_all_cookies():
 
     # Test cookie carving by passing cookies directly to carve_all_modules.
     r_list = carve_all_modules(cookies=cookies)
+    # 7 distinct cookies have known secrets in our wordlists. With at least
+    # one SecretFound present, all IdentifyOnly results are suppressed.
     assert len(r_list) == 7
+    assert all(r["type"] == "SecretFound" for r in r_list)
 
 
 def test_carve_multiple_vulns():
@@ -133,7 +140,12 @@ def test_carve_multiple_vulns():
 
     res = FakeResponse(text=multiple_vuln_html)
     r_list = carve_all_modules(http_response=res)
-    assert len(r_list) == 2
+    # ASPNET_Viewstate finds the MachineKey (SecretFound). The compressed
+    # __VSTATE value also gets identified by ASPNET_CompressedViewstate,
+    # but IdentifyOnly results are suppressed when any SecretFound exists.
+    assert len(r_list) == 1
+    assert r_list[0]["type"] == "SecretFound"
+    assert r_list[0]["detecting_module"] == "ASPNET_Viewstate"
 
 
 def test_multiple_identify_only():

--- a/tests/carve_test.py
+++ b/tests/carve_test.py
@@ -24,6 +24,9 @@ Rails_SecretKeyBase = modules_loaded["rails_secretkeybase"]
 Generic_JWT = modules_loaded["generic_jwt"]
 Jsf_viewstate = modules_loaded["jsf_viewstate"]
 Express_SignedCookies_ES = modules_loaded["express_signedcookies_es"]
+LaravelSignedCookies = modules_loaded["laravel_signedcookies"]
+Yii2_SignedCookies = modules_loaded["yii2_signedcookies"]
+Rack2_SignedCookies = modules_loaded["rack2_signedcookies"]
 
 aspnet_viewstate_sample = """
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -410,3 +413,116 @@ def test_carve_aspnet_viewstate_userkey():
     assert len(r) == 1
     assert r[0]["type"] == "SecretFound"
     assert "/wEPDwUJODExMDE5NzY5ZGTX0g6r3svRDbR+eCZDnrj4MT4/FA==" in r[0]["product"]
+
+
+# Cookies-branch IdentifyOnly fallback: when carve() sees a cookie that matches
+# a module's identify_regex but the secret isn't in the wordlist, the cookies
+# branch must emit an IdentifyOnly result (mirroring the headers/body branches).
+# Regression for the Laravel report — and lock in the symmetry across every
+# module whose carve_locations is ("cookies",).
+
+
+def _identify_only_fallback(module_cls, cookie_name, cookie_value, expected_module_name=None):
+    x = module_cls()
+    # Sanity: the fixture cookie must match identify_regex but not be a known secret
+    assert x.identify(cookie_value), f"fixture cookie does not match {module_cls.__name__}.identify_regex"
+    assert x.check_secret(cookie_value) is None, f"fixture cookie unexpectedly matched a known secret"
+
+    r = x.carve(cookies={cookie_name: cookie_value})
+    assert r, "expected IdentifyOnly result, got nothing"
+    assert len(r) == 1
+    assert r[0]["type"] == "IdentifyOnly"
+    assert r[0]["location"] == "cookies"
+    assert r[0]["product"] == cookie_value
+
+
+def test_carve_cookies_identifyonly_laravel():
+    _identify_only_fallback(
+        LaravelSignedCookies,
+        "laravel_session",
+        "eyJpdiI6IlhlNTZ2UjZUQWZKVHdIcG9nZFkwcGc9PSIsInZhbHVlIjoiQUFBIiwibWFjIjoiYWFhIiwidGFnIjoiIn0%3D",
+    )
+
+
+def test_carve_cookies_identifyonly_django():
+    # Django session cookie format: encoded:signature1:signature2 — matches
+    # ^[\.a-zA-z-0-9]+:[\.a-zA-z-0-9:]+$ but uses a key that isn't in the wordlist.
+    _identify_only_fallback(
+        Django_SignedCookies,
+        "sessionid",
+        "AAAA-not-a-real-django-session-aaaa:1ojOrE:bfOktjgLlUykwCIRIpvaTZRQMM3-NotAValidSecret",
+    )
+
+
+def test_carve_cookies_identifyonly_flask():
+    # Flask signed cookie format: eyJ.eyJ.signature
+    _identify_only_fallback(
+        Flask_SignedCookies,
+        "session",
+        "eyJoZWxsbyI6Im5vdGFyZWFsa2V5In0.AAAAAA.AAAAAAAAAAAAAAAAAAAAAA-NotAValidSig",
+    )
+
+
+def test_carve_cookies_identifyonly_rack2():
+    # Rack/Rails 5+ session format: BAh<marshal_b64>--<hmac_b64>
+    # Rack/Rails 5+ format: marshal_b64--hmac. First half must be proper-length b64
+    # because get_hashcat_commands() base64-decodes it.
+    _identify_only_fallback(
+        Rack2_SignedCookies,
+        "_session_id",
+        "BAh" + "A" * 61 + "--" + "B" * 32,
+    )
+
+
+def test_carve_cookies_identifyonly_yii2():
+    # Yii2 cookie format: 64 hex chars + a%3A<url-encoded payload>
+    _identify_only_fallback(
+        Yii2_SignedCookies,
+        "_identity",
+        "a" * 64 + "a%3A" + "AAAAAAAAAAAAAAAAAAAAAAAAA",
+    )
+
+
+def test_carve_cookies_identifyonly_express():
+    # Express signed cookie format: s%3A<sid>.<sig>
+    _identify_only_fallback(
+        Express_SignedCookies_ES,
+        "session",
+        "s%3AAAAAAAAAAAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    )
+
+
+def test_carve_cookies_unrelated_value_is_skipped():
+    """A garbage cookie that matches no identify_regex must NOT emit IdentifyOnly."""
+    x = LaravelSignedCookies()
+    r = x.carve(cookies={"random": "totally-unrelated-value"})
+    assert not r
+
+
+# Manual/product-mode IdentifyOnly fallback:
+# `check_all_modules(<unknown_laravel_cookie>)` must surface IdentifyOnly results
+# from every module that identifies the input, not just SecretFound matches.
+# This is the path used by `badsecrets <product>` (no --url) and was a sister
+# blind spot to the cookies-branch carve() bug.
+
+
+def test_check_all_modules_identifyonly_laravel():
+    from badsecrets.base import check_all_modules
+
+    fake_laravel = "eyJpdiI6IlhlNTZ2UjZUQWZKVHdIcG9nZFkwcGc9PSIsInZhbHVlIjoiQUFBIiwibWFjIjoiYWFhIiwidGFnIjoiIn0%3D"
+    r = check_all_modules(fake_laravel)
+    assert r, "expected at least one IdentifyOnly result for a recognizable Laravel cookie"
+    assert any(d["detecting_module"] == "LaravelSignedCookies" and d["type"] == "IdentifyOnly" for d in r), (
+        f"LaravelSignedCookies did not identify the cookie; got: {[(d['detecting_module'], d['type']) for d in r]}"
+    )
+    # All hits should carry the manual location label
+    for d in r:
+        assert d["location"] == "manual"
+
+
+def test_check_all_modules_identifyonly_no_match():
+    from badsecrets.base import check_all_modules
+
+    # A short garbage string matches no identify_regex
+    r = check_all_modules("totally-unrelated-value")
+    assert r is None

--- a/tests/examples_cli_test.py
+++ b/tests/examples_cli_test.py
@@ -230,7 +230,10 @@ def test_example_cli_identifyonly_hashcat(monkeypatch, capsys, bh_mock):
     cli.main()
     captured = capsys.readouterr()
     print(captured)
-    assert "No secrets found :(" in captured.out
+    # The CLI now surfaces an IdentifyOnly report instead of bailing with
+    # "No secrets found :(" when a recognizable product is given but the
+    # secret isn't in the wordlist.
+    assert "Cryptographic Product Identified" in captured.out
     assert "Potential matching hashcat commands:" in captured.out
     assert "JSON Web Token (JWT) Algorithm: HS256 Command: [hashcat -m 16500" in captured.out
 
@@ -253,7 +256,7 @@ def test_example_cli_identifyonly_hashcat_rack2(monkeypatch, capsys, bh_mock):
     captured = capsys.readouterr()
     print(captured)
 
-    assert "No secrets found :(" in captured.out
+    assert "Cryptographic Product Identified" in captured.out
     assert "[Rack2_SignedCookies] Rack 2.x Signed Cookie" in captured.out
     assert "Potential matching hashcat commands" in captured.out
 


### PR DESCRIPTION
## Summary

Closes the gap reported on `main @ 6a7aa49` where `badsecrets -u <laravel-protected-site>` printed "No secrets found :(" even though the Laravel cookie was correctly identified — only the APP_KEY wasn't in the wordlist.

## What changed

- `carve()` cookies branch: adds an IdentifyOnly fallback gated on `validate_carve`, mirroring the headers and body branches.
- `check_all_modules()` (the `badsecrets <product>` path): now runs `identify()` after `check_secret` misses and returns a list of dicts (each tagged `SecretFound` or `IdentifyOnly`), matching `carve_all_modules()`.
- `carve_all_modules()` and `check_all_modules()` both suppress every IdentifyOnly result whenever any SecretFound exists — actionable hits outrank recognition-only candidates.
- `cli.py` product-mode iterates the new list and dispatches SecretFound vs IdentifyOnly to the appropriate report. URL-mode unchanged.

## Safety: identify_regex audit

All eight modules whose `carve_locations` includes `cookies` (laravel, django, flask, rack2, yii2, express, shiro, ltpa) ship a specific `identify_regex` — none rely on the default `r".+"`. The `validate_carve` gate is the kill switch if any future module forgets to override.

## bbot compatibility

bbot only imports `carve_all_modules`, which already returns a list. No changes needed on the bbot side.