### PR TITLE
fix: guard IdentifyOnly crashes, false positives, and hashcat bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,17 +522,19 @@ else:
 ```
 
 #### Carve
-An additional layer of abstraction above check_secret, which accepts an httpx.Response object or a string
+An additional layer of abstraction above check_secret, which accepts an HTTP response object (e.g. blasthttp) or raw body/cookies/headers
 
 ```python
-import httpx
+import asyncio
+from blasthttp import BlastHTTP
 from badsecrets import modules_loaded
 Telerik_HashKey = modules_loaded["telerik_hashkey"]
 
 x = Telerik_HashKey()
 
-res = httpx.get("http://example.com/")
-r_list = x.carve(httpx_response=res)
+client = BlastHTTP()
+res = asyncio.run(client.request("http://example.com/"))
+r_list = x.carve(http_response=res)
 print(r_list)
 
 telerik_dialogparameters_sample = """
@@ -564,9 +566,10 @@ tests = [
 ]
 
 for test in tests:
-    r = check_all_modules(test)
-    if r:
-        print(r)
+    results = check_all_modules(test)
+    if results:
+        for r in results:
+            print(f"[{r['type']}] {r['detecting_module']}: {r['description']}")
     else:
         print("Key not found!")
 ```
@@ -574,13 +577,15 @@ for test in tests:
 
 ### Carve all modules at once
 ```python
-import httpx
+import asyncio
+from blasthttp import BlastHTTP
 from badsecrets.base import carve_all_modules
 
-### using httpx response object
+### using http response object
 
-res = httpx.get("http://example.com/")
-r_list = carve_all_modules(httpx_response=res)
+client = BlastHTTP()
+res = asyncio.run(client.request("http://example.com/"))
+r_list = carve_all_modules(http_response=res)
 print(r_list)
 
 ### Using string

--- a/badsecrets/base.py
+++ b/badsecrets/base.py
@@ -35,6 +35,7 @@ class BadsecretsBase:
 
     check_secret_args = 1
     validate_carve = True
+    cookie_identify_only = True
     carve_locations = ("headers", "cookies", "body")
 
     def __init__(self, custom_resource=None, **kwargs):
@@ -67,6 +68,13 @@ class BadsecretsBase:
 
     def get_hashcat_commands(self, s):
         return None
+
+    def _safe_hashcat(self, product):
+        try:
+            return self.get_hashcat_commands(product)
+        except Exception:
+            log.debug(f"{type(self).__name__}.get_hashcat_commands() failed for product value", exc_info=True)
+            return None
 
     def load_resources(self, resource_list):
         filepaths = []
@@ -116,8 +124,8 @@ class BadsecretsBase:
                 if r:
                     r["type"] = "SecretFound"
                     r["product"] = v
-                elif self.validate_carve and self.identify(v):
-                    r = {"type": "IdentifyOnly", "product": v, "hashcat": self.get_hashcat_commands(v)}
+                elif self.validate_carve and self.cookie_identify_only and self.identify(v):
+                    r = {"type": "IdentifyOnly", "product": v, "hashcat": self._safe_hashcat(v)}
                 else:
                     continue
                 r["location"] = "cookies"
@@ -143,7 +151,7 @@ class BadsecretsBase:
                             # the carve regex hit but no secret was found
                             else:
                                 r = {"type": "IdentifyOnly"}
-                                r["hashcat"] = self.get_hashcat_commands(s.groups()[0])
+                                r["hashcat"] = self._safe_hashcat(s.groups()[0])
                             if "product" not in r:
                                 r["product"] = self.get_product_from_carve(s)
                             r["location"] = "headers"
@@ -192,7 +200,7 @@ class BadsecretsBase:
                         r["type"] = "SecretFound"
                     else:
                         r = {"type": "IdentifyOnly"}
-                        r["hashcat"] = self.get_hashcat_commands(s.groups()[0])
+                        r["hashcat"] = self._safe_hashcat(s.groups()[0])
                     if "product" not in r:
                         r["product"] = self.get_product_from_carve(s)
                     r["location"] = "body"

--- a/badsecrets/modules/passive/django_signedcookies.py
+++ b/badsecrets/modules/passive/django_signedcookies.py
@@ -4,7 +4,7 @@ from badsecrets.base import BadsecretsBase
 
 
 class DjangoSignedCookies(BadsecretsBase):
-    identify_regex = re.compile(r"^[\.a-zA-z-0-9]+:[\.a-zA-z-0-9:]+$")
+    identify_regex = re.compile(r"^[\.a-zA-Z_\-0-9]+:[\.a-zA-Z_\-0-9:]+$")
     description = {"product": "Django Signed Cookie", "secret": "Django secret_key", "severity": "HIGH"}
     carve_locations = ("cookies",)
 

--- a/badsecrets/modules/passive/ltpa_token.py
+++ b/badsecrets/modules/passive/ltpa_token.py
@@ -31,6 +31,7 @@ class LTPA_Token(BadsecretsBase):
     # formats; this prevents cross-module false positives.
     identify_regex = re.compile(r"^(?!eyJ)(?:[A-Za-z0-9+/]{4}){16,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
     description = {"product": "IBM WebSphere LTPA", "secret": "LTPA Encryption Key", "severity": "HIGH"}
+    cookie_identify_only = False
     carve_locations = ("cookies",)
 
     def __init__(self, custom_resource=None, **kwargs):

--- a/badsecrets/modules/passive/peoplesoft_pstoken.py
+++ b/badsecrets/modules/passive/peoplesoft_pstoken.py
@@ -12,6 +12,7 @@ class Peoplesoft_PSToken(BadsecretsBase):
         r"^(?!eyJ)(?:[A-Za-z0-9+\/]{4}){8,}(?:[A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}={2})$"
     )
     description = {"product": "Peoplesoft PS_TOKEN", "secret": "Peoplesoft Secret", "severity": "HIGH"}
+    cookie_identify_only = False
 
     def peoplesoft_load(self, PS_TOKEN_B64):
         PS_TOKEN = base64.b64decode(PS_TOKEN_B64)

--- a/badsecrets/modules/passive/rack2_signedcookies.py
+++ b/badsecrets/modules/passive/rack2_signedcookies.py
@@ -6,8 +6,8 @@ from urllib.parse import unquote
 
 
 class Rack2_SignedCookies(BadsecretsBase):
-    identify_regex = re.compile(r"^BAh[\.a-zA-z-0-9\%=]{32,}--[\.a-zA-z-0-9%=]{16,}$")
-    yara_carve_pattern = r"session=BAh[\.a-zA-z\-0-9\%=]{32,500}--[\.a-zA-z\-0-9%=]{16,}"
+    identify_regex = re.compile(r"^BAh[\.a-zA-Z-0-9\%=]{32,}--[\.a-zA-Z-0-9%=]{16,}$")
+    yara_carve_pattern = r"session=BAh[\.a-zA-Z\-0-9\%=]{32,500}--[\.a-zA-Z\-0-9%=]{16,}"
     description = {
         "product": "Rack 2.x Signed Cookie (Ruby Serialized Object)",
         "secret": "Rack 2.x secret key",
@@ -16,7 +16,7 @@ class Rack2_SignedCookies(BadsecretsBase):
     carve_locations = ("cookies",)
 
     def carve_regex(self):
-        return re.compile(r"session=(BAh[\.a-zA-z-0-9\%=]{32,}--[\.a-zA-z-0-9%=]{16,})")
+        return re.compile(r"session=(BAh[\.a-zA-Z-0-9\%=]{32,}--[\.a-zA-Z-0-9%=]{16,})")
 
     def rack2(self, rack_cookie, secret_key):
         # Split the cookie into data and signature
@@ -50,9 +50,13 @@ class Rack2_SignedCookies(BadsecretsBase):
 
     def get_hashcat_commands(self, rack_cookie, *args):
         rack_cookie_split = rack_cookie.rsplit("--", 1)
+        try:
+            data_hex = base64.b64decode(unquote(rack_cookie_split[0])).hex()
+        except Exception:
+            return None
         return [
             {
-                "command": f"hashcat -m 150 -a 0 {rack_cookie_split[1]}:{base64.b64decode(unquote(rack_cookie_split[0])).hex()} --hex-salt  <dictionary_file>",
+                "command": f"hashcat -m 150 -a 0 {rack_cookie_split[1]}:{data_hex} --hex-salt  <dictionary_file>",
                 "description": "Rack 2.x Signed Cookie (HMAC-SHA1)",
             }
         ]

--- a/badsecrets/modules/passive/rails_secretkeybase.py
+++ b/badsecrets/modules/passive/rails_secretkeybase.py
@@ -11,7 +11,7 @@ from badsecrets.base import BadsecretsBase
 
 
 class Rails_SecretKeyBase(BadsecretsBase):
-    identify_regex = re.compile(r"^[\.a-zA-z-0-9\%=]{32,}--[\.a-zA-z-0-9%=]{16,}$")
+    identify_regex = re.compile(r"^[\.a-zA-Z-0-9\%=]{32,}--[\.a-zA-Z-0-9%=]{16,}$")
     description = {"product": "Rails Signed Cookie", "secret": "Rails secret_key_base", "severity": "HIGH"}
 
     def rails(self, rails_cookie, secret_key_base):

--- a/badsecrets/modules/passive/shiro_rememberme.py
+++ b/badsecrets/modules/passive/shiro_rememberme.py
@@ -15,6 +15,7 @@ class Shiro_RememberMe(BadsecretsBase):
     # AES-encrypted random bytes and don't legitimately start with `eyJ`.
     identify_regex = re.compile(r"^(?!eyJ)(?:[A-Za-z0-9+/]{4}){11,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")
     description = {"product": "Apache Shiro", "secret": "RememberMe AES Key", "severity": "CRITICAL"}
+    cookie_identify_only = False
     carve_locations = ("cookies",)
 
     def check_secret(self, cookie_value):

--- a/badsecrets/modules/passive/telerik_hashkey.py
+++ b/badsecrets/modules/passive/telerik_hashkey.py
@@ -57,14 +57,16 @@ class Telerik_HashKey(BadsecretsBase):
             return None
 
         try:
-            dp_enc_decoded = base64.b64decode(dp_hash)
-            dp_hash_decoded = base64.b64decode(dp_enc)
+            hmac_hex = base64.b64decode(dp_hash).hex()
+            base64.b64decode(dp_enc)
         except binascii.Error:
             return None
 
+        msg_hex = dp_enc.hex()
+
         return [
             {
-                "command": f"hashcat -m 1450 -a 0 {dp_enc_decoded.hex()}:{dp_hash_decoded.hex()} --hex-salt <dictionary_file>",
+                "command": f"hashcat -m 1450 -a 0 {hmac_hex}:{msg_hex} --hex-salt <dictionary_file>",
                 "description": f"Telerik Hash Key Signature",
             }
         ]

--- a/tests/carve_test.py
+++ b/tests/carve_test.py
@@ -526,3 +526,33 @@ def test_check_all_modules_identifyonly_no_match():
     # A short garbage string matches no identify_regex
     r = check_all_modules("totally-unrelated-value")
     assert r is None
+
+
+def test_carve_malformed_rack2_cookie_no_crash():
+    """A Rack2-shaped cookie with bad base64 padding must not crash carve_all_modules."""
+    from badsecrets.base import carve_all_modules
+
+    clipped = (
+        "BAh7B0kiD3Nlc3Npb25faWQGOgZFVG86HVJhY2s6OlNlc3Npb246OlNlc3Npb25JZAY6D0BwdWJsaWNf"
+        "aWRJIkU5YmI3ZDUyODUyNTAwMDYzMGE2NjMxYTA5MjBlMjYzMzFmOGE0MjBhNTdhYWIxNzVkZTFmM2Fj"
+        "MDQ3NmI1NDQzBjsARkkiCmNvdW50BjsARmkG--3a983fbc58911c5266d7748a6a55165f74d412f"
+    )
+    results = carve_all_modules(cookies={"rack.session": clipped})
+    assert isinstance(results, list) or results is None
+
+
+def test_carve_awsalb_no_false_shiro_identifyonly():
+    """An ordinary AWSALB cookie must not produce Shiro/PeopleSoft/LTPA IdentifyOnly."""
+    import base64
+    import os
+    from badsecrets.base import carve_all_modules
+
+    awsalb = base64.b64encode(os.urandom(96)).decode()
+    results = carve_all_modules(cookies={"AWSALB": awsalb})
+    if results:
+        false_positives = [
+            r for r in results
+            if r["type"] == "IdentifyOnly"
+            and r.get("detecting_module") in ("Shiro_RememberMe", "Peoplesoft_PSToken", "LTPA_Token")
+        ]
+        assert not false_positives, f"unexpected false IdentifyOnly hits: {false_positives}"

--- a/tests/carve_test.py
+++ b/tests/carve_test.py
@@ -551,7 +551,8 @@ def test_carve_awsalb_no_false_shiro_identifyonly():
     results = carve_all_modules(cookies={"AWSALB": awsalb})
     if results:
         false_positives = [
-            r for r in results
+            r
+            for r in results
             if r["type"] == "IdentifyOnly"
             and r.get("detecting_module") in ("Shiro_RememberMe", "Peoplesoft_PSToken", "LTPA_Token")
         ]

--- a/tests/telerik_hashkey_test.py
+++ b/tests/telerik_hashkey_test.py
@@ -1,3 +1,5 @@
+import hmac
+import hashlib
 import urllib.parse
 from badsecrets import modules_loaded
 
@@ -57,3 +59,28 @@ def test_sign_enc_dialog_params():
 
     assert r
     assert r["secret"] == test_hashkey
+
+
+def test_hashcat_command_correctness():
+    """Validate that get_hashcat_commands produces a command whose hash:salt
+    matches the actual HMAC computation from check_secret."""
+    x = Telerik_HashKey()
+
+    for params, key in x.hashkey_probe_generator(include_machinekeys=False):
+        assert x.check_secret(params), "probe should be crackable"
+
+        cmds = x.get_hashcat_commands(params)
+        assert cmds and len(cmds) == 1
+
+        # hashcat 1450 format: hashcat -m 1450 -a 0 <hmac_hex>:<msg_hex> --hex-salt ...
+        parts = cmds[0]["command"].split()
+        hash_salt = parts[5]
+        cmd_hmac_hex, cmd_msg_hex = hash_salt.split(":")
+
+        # Recompute the HMAC the same way check_secret does
+        dp_enc, dp_hash = x.telerik_hashkey_load(params)
+        h = hmac.new(key.encode(), dp_enc, hashlib.sha256)
+
+        assert cmd_hmac_hex == h.hexdigest(), "hashcat hash field must match the real HMAC digest"
+        assert cmd_msg_hex == dp_enc.hex(), "hashcat salt field must be the hex of the base64 message bytes"
+        break


### PR DESCRIPTION
- Guard `get_hashcat_commands` calls with `_safe_hashcat` wrapper so malformed cookie values can't crash the entire passive scan (or bbot's `carve_all_modules`)
- Add `cookie_identify_only` opt-out for Shiro, PeopleSoft, and LTPA — their broad base64 regexes were false-positive IdentifyOnly-ing on ordinary cookies like AWSALB
- Fix `A-z` char-class typo → `A-Z` in rack2, rails, django regexes; add `_` to django regex for URL-safe base64
- Fix `Telerik_HashKey.get_hashcat_commands`: variables were swapped and message was b64-decoded instead of hex-encoded — produced non-cracking hashcat commands
- Guard `Rack2.get_hashcat_commands` against `binascii.Error` on malformed base64
- Update README library examples from httpx → blasthttp / `http_response=`
- Update README `check_all_modules` example for list return type