### PR TITLE
fix: disable aud/nbf claim validation in JWT secret detection

### DIFF
--- a/badsecrets/modules/passive/generic_jwt.py
+++ b/badsecrets/modules/passive/generic_jwt.py
@@ -49,7 +49,12 @@ class Generic_JWT(BadsecretsBase):
         try:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=j.warnings.InsecureKeyLengthWarning)
-                r = j.decode(JWT, key, algorithms=[algorithm], options={"verify_exp": False})
+                r = j.decode(
+                    JWT,
+                    key,
+                    algorithms=[algorithm],
+                    options={"verify_exp": False, "verify_aud": False, "verify_nbf": False},
+                )
             return r
         except j.exceptions.InvalidSignatureError:
             return None

--- a/tests/generic_jwt_test.py
+++ b/tests/generic_jwt_test.py
@@ -45,6 +45,33 @@ def test_generic_jwt_xmldsig():
     assert found_key
 
 
+def test_generic_jwt_hmac_with_aud():
+    x = Generic_JWT()
+    found_key = x.check_secret(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0IiwiYXVkIjoibXktYXBwIiwicm9sZSI6ImFkbWluIn0.t9-1JUdynKdC1ZBGxtj70ySnD-0npSocNUVXmqo2-8s"
+    )
+    assert found_key
+    assert found_key["secret"] == "1234"
+
+
+def test_generic_jwt_hmac_with_iss():
+    x = Generic_JWT()
+    found_key = x.check_secret(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0IiwiaXNzIjoiZXZpbC1jb3JwIiwicm9sZSI6ImFkbWluIn0.VR43bXZc6k5ZAZwp4mRr-D18NkQ8EN9D46EQsV8Vazw"
+    )
+    assert found_key
+    assert found_key["secret"] == "1234"
+
+
+def test_generic_jwt_hmac_with_nbf():
+    x = Generic_JWT()
+    found_key = x.check_secret(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0IiwibmJmIjo5OTk5OTk5OTk5LCJyb2xlIjoiYWRtaW4ifQ.aZlX94Q-6bOXZHARHTEMqVZZKz0kmQ4XEZziz6rh9vw"
+    )
+    assert found_key
+    assert found_key["secret"] == "1234"
+
+
 def test_generic_jwt_loadfail():
     x = Generic_JWT()
     found_key = x.check_secret(


### PR DESCRIPTION
## Summary

Closes #412.

- `jwt.decode()` raised `InvalidAudienceError` / `ImmatureSignatureError` for tokens with `aud` or `nbf` claims, silently skipping valid weak secrets
- Added `verify_aud: False` and `verify_nbf: False` to decode options alongside the existing `verify_exp` exemption
- Added tests for JWTs containing `aud`, `iss`, and `nbf` claims