### PR TITLE
Switch dependabot from pip to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary
- Switch dependabot `package-ecosystem` from `pip` to `uv` so it updates `uv.lock` instead of trying to generate a `poetry.lock`
- See https://docs.astral.sh/uv/guides/integration/dependabot/