### PR TITLE
fix: tighten Django signed cookie identify_regex to cut false positives

### DIFF
--- a/badsecrets/modules/passive/django_signedcookies.py
+++ b/badsecrets/modules/passive/django_signedcookies.py
@@ -4,7 +4,7 @@ from badsecrets.base import BadsecretsBase
 
 
 class DjangoSignedCookies(BadsecretsBase):
-    identify_regex = re.compile(r"^[\.a-zA-Z_\-0-9]+:[\.a-zA-Z_\-0-9:]+$")
+    identify_regex = re.compile(r"^\.?[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]{4,8})?:[a-zA-Z0-9_-]{27,}$")
     description = {"product": "Django Signed Cookie", "secret": "Django secret_key", "severity": "HIGH"}
     carve_locations = ("cookies",)
 

--- a/tests/carve_test.py
+++ b/tests/carve_test.py
@@ -445,8 +445,9 @@ def test_carve_cookies_identifyonly_laravel():
 
 
 def test_carve_cookies_identifyonly_django():
-    # Django session cookie format: encoded:signature1:signature2 — matches
-    # ^[\.a-zA-z-0-9]+:[\.a-zA-z-0-9:]+$ but uses a key that isn't in the wordlist.
+    # Django session cookie format: payload:timestamp:signature — matches
+    # identify_regex (signature is a 27+ char base64url HMAC) but uses a key
+    # that isn't in the wordlist.
     _identify_only_fallback(
         Django_SignedCookies,
         "sessionid",

--- a/tests/django_signedcookies_test.py
+++ b/tests/django_signedcookies_test.py
@@ -24,3 +24,12 @@ def test_django_negative():
         ".eJxVjLsOAiEURP-F2hAuL8HSfr-BAPciq4ZNlt3K-O9KsoU2U8w5My8W4r7VsHdaw4zswoCdfrsU84PaAHiP7bbwvLRtnRMfCj9o59OC9Lwe7t9Bjb2OtbMkAEGQtQjekykmJy9JZIW-6CgUaCGsA6eSyV65s1Qya_xGKZrY-wPVYjdw:1ojOrE:bfOktjgLlUykwCBADSECRETSMM3-UypscEN57ECtXis"
     )
     assert not found_key
+
+
+def test_django_identify_false_positives():
+    x = DjangoSignedCookies()
+    assert not x.identify("abc:def")
+    assert not x.identify("a:b")
+    assert not x.identify("0000Qs-hTQlwlgXAYBlmgEFoQTR:1ffkg4vkm")
+    assert not x.identify("test:1234")
+    assert not x.identify("JSESSIONID:abcdef1234")


### PR DESCRIPTION
## Problem

`DjangoSignedCookies.identify_regex` matched any two colon-separated alphanumeric segments with **no minimum length**:

```python
identify_regex = re.compile(r"^[\.a-zA-Z_\-0-9]+:[\.a-zA-Z_\-0-9:]+$")
```

This produced `IdentifyOnly` false positives on short values like `abc:def`, `JSESSIONID:abcdef1234`, and government app tokens such as `0000Qs-hTQlwlgXAYBlmgEFoQTR:1ffkg4vkm`. Every other module in the library enforces minimum lengths (Rails `{32,}--{16,}`, Telerik `{32,}`, Express `{20,90}`); this one did not.

## Fix

```python
identify_regex = re.compile(r"^\.?[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]{4,8})?:[a-zA-Z0-9_-]{27,}$")
```

- `^\.?` — optional leading dot (zlib-compressed payloads)
- `[a-zA-Z0-9_-]+` — base64url payload
- `(?::[a-zA-Z0-9_-]{4,8})?` — optional base62 timestamp segment (`TimestampSigner`/`dumps`)
- `:[a-zA-Z0-9_-]{27,}$` — base64url HMAC signature (SHA-1 = 27 chars, SHA-256 = 43 chars)

## Why this is complete (no old/new format split)

`django.core.signing` only ever emits two shapes, both `:`-separated: `payload:signature` (`Signer`) and `payload:timestamp:signature` (`TimestampSigner`/`dumps`). The only historical variation is the hash algorithm — SHA-1 (legacy, pre-3.1) → 27-char signature, SHA-256 (default since Django 3.1) → 43-char signature — both covered by `{27,}`. The middle segment is a base62 timestamp (6 chars this era; `{4,8}` has wide headroom), never a second signature. Verified by generating real cookies with the installed Django across `Signer`/`TimestampSigner` and both algorithms — all match.

## Validation

Real Django cookies (all match): test-suite cookie, minimal `TimestampSigner`, minimal plain `Signer`, empty session dump, SHA-1 variants.

False positives (all rejected): `0000Qs-hTQlwlgXAYBlmgEFoQTR:1ffkg4vkm`, `abc:def`, `a:b`, `test:1234`, `JSESSIONID:abcdef1234`, `foo:bar:baz`.

## Tests

- Added `test_django_identify_false_positives` to `tests/django_signedcookies_test.py`.
- Existing `tests/django_signedcookies_test.py` and `tests/carve_test.py` pass unmodified (corrected a stale comment that mislabeled the timestamp segment).
- `uv run pytest tests/django_signedcookies_test.py tests/carve_test.py` → 27 passed.